### PR TITLE
revert: xunit v3 migration

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -36,6 +36,7 @@
         "CodeAnalysisEnd",
         "CodeCoverage",
         "Compile",
+        "DotNetFrameworkUnitTests",
         "DotNetUnitTests",
         "MutationComment",
         "MutationTestExecution",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,10 +21,13 @@
 		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.163"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13" />
+		<PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13"/>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
 		<PackageVersion Include="BenchmarkDotNet" Version="0.14.0"/>
-		<PackageVersion Include="xunit.v3" Version="1.1.0"/>
+		<PackageVersion Include="NUnit" Version="4.3.2"/>
+		<PackageVersion Include="NUnit3TestAdapter" Version="4.6.0"/>
+		<PackageVersion Include="NUnit.Analyzers" Version="4.6.0"/>
+		<PackageVersion Include="xunit" Version="2.9.3"/>
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.4"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.4.2"/>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -8,7 +8,6 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<OutputType>exe</OutputType>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -19,7 +18,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit.v3"/>
+		<PackageReference Include="xunit"/>
 		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/Tests/aweXpect.Web.Api.Tests/ApiAcceptance.cs
+++ b/Tests/aweXpect.Web.Api.Tests/ApiAcceptance.cs
@@ -5,7 +5,8 @@ public sealed class ApiAcceptance
 	/// <summary>
 	///     Execute this test to update the expected public API to the current API surface.
 	/// </summary>
-	[Fact(Explicit = true)]
+	[TestCase]
+	[Explicit]
 	public async Task AcceptApiChanges()
 	{
 		string[] assemblyNames =

--- a/Tests/aweXpect.Web.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Web.Api.Tests/ApiApprovalTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Api.Tests;
+﻿using System.Collections.Generic;
+
+namespace aweXpect.Api.Tests;
 
 /// <summary>
 ///     Whenever a test fails, this means that the public API surface changed.
@@ -7,8 +9,7 @@
 /// </summary>
 public sealed class ApiApprovalTests
 {
-	[Theory]
-	[MemberData(nameof(TargetFrameworksTheoryData))]
+	[TestCaseSource(nameof(TargetFrameworksTheoryData))]
 	public async Task VerifyPublicApiForAweXpectWeb(string framework)
 	{
 		const string assemblyName = "aweXpect.Web";
@@ -19,9 +20,9 @@ public sealed class ApiApprovalTests
 		await That(publicApi).IsEqualTo(expectedApi);
 	}
 
-	public static TheoryData<string> TargetFrameworksTheoryData()
+	public static IEnumerable<string> TargetFrameworksTheoryData()
 	{
-		TheoryData<string> theoryData = new();
+		List<string> theoryData = new();
 		foreach (string targetFramework in Helper.GetTargetFrameworks())
 		{
 			theoryData.Add(targetFramework);

--- a/Tests/aweXpect.Web.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Web.Api.Tests/ApiApprovalTests.cs
@@ -20,7 +20,7 @@ public sealed class ApiApprovalTests
 		await That(publicApi).IsEqualTo(expectedApi);
 	}
 
-	public static IEnumerable<string> TargetFrameworksTheoryData()
+	private static IEnumerable<string> TargetFrameworksTheoryData()
 	{
 		List<string> theoryData = new();
 		foreach (string targetFramework in Helper.GetTargetFrameworks())

--- a/Tests/aweXpect.Web.Api.Tests/Usings.cs
+++ b/Tests/aweXpect.Web.Api.Tests/Usings.cs
@@ -1,5 +1,5 @@
 ﻿global using System;
 global using System.Threading.Tasks;
-global using Xunit;
+global using NUnit.Framework;
 global using aweXpect;
 global using static aweXpect.Expect;

--- a/Tests/aweXpect.Web.Api.Tests/aweXpect.Web.Api.Tests.csproj
+++ b/Tests/aweXpect.Web.Api.Tests/aweXpect.Web.Api.Tests.csproj
@@ -9,6 +9,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Remove="xunit"/>
+		<PackageReference Remove="xunit.runner.visualstudio"/>
+		<PackageReference Include="NUnit"/>
+		<PackageReference Include="NUnit.Analyzers"/>
+		<PackageReference Include="NUnit3TestAdapter"/>
 		<PackageReference Include="PublicApiGenerator"/>
 	</ItemGroup>
 

--- a/Tests/aweXpect.Web.Samples.Tests/CommentsTests.cs
+++ b/Tests/aweXpect.Web.Samples.Tests/CommentsTests.cs
@@ -13,7 +13,7 @@ public class CommentsTests(WebApplicationFactory<Program> factory) : IClassFixtu
 	{
 		HttpClient client = factory.CreateClient();
 
-		HttpResponseMessage response = await client.GetAsync("/comments", TestContext.Current.CancellationToken);
+		HttpResponseMessage response = await client.GetAsync("/comments");
 
 		await Expect.That(response).HasStatusCode().EqualTo(HttpStatusCode.OK);
 	}


### PR DESCRIPTION
Revert back the xunit v3 migration, as [Stryker.NET doesn't handle xUnit v3 properly](https://github.com/stryker-mutator/stryker-net/issues/3117).