### PR TITLE
feat: add `HasStatusCode` with parameter

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -24,7 +24,7 @@ You can verify, that the status code of the `HttpResponseMessage`:
 ```csharp
 HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect");
 await Expect.That(response).HasStatusCode().Success();
-await Expect.That(response).HasStatusCode().EqualTo(HttpStatusCode.OK);
+await Expect.That(response).HasStatusCode(HttpStatusCode.OK);
 
 response = await httpClient.PostAsync("https://github.com/aweXpect/aweXpect", new StringContent(""));
 await Expect.That(response).HasStatusCode().ClientError().Or.HasStatusCode().ServerError().Or.HasStatusCode().Redirection();

--- a/Source/aweXpect.Web/StatusCodeResult.cs
+++ b/Source/aweXpect.Web/StatusCodeResult.cs
@@ -110,7 +110,7 @@ public class StatusCodeResult(
 					"has an error status code (4xx or 5xx)")),
 			source);
 
-	private readonly struct PropertyConstraint(
+	internal readonly struct PropertyConstraint(
 		string it,
 		HttpStatusCode? expected,
 		Func<HttpResponseMessage, HttpStatusCode> mapper,

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasStatusCode.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasStatusCode.cs
@@ -1,5 +1,8 @@
-﻿using System.Net.Http;
+﻿using System.Net;
+using System.Net.Http;
 using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Results;
 
 namespace aweXpect;
 
@@ -10,4 +13,19 @@ public static partial class ThatHttpResponseMessage
 	/// </summary>
 	public static StatusCodeResult HasStatusCode(this IThat<HttpResponseMessage?> source)
 		=> new(source, a => a.StatusCode);
+
+	/// <summary>
+	///     Verifies that the status code of the <see cref="HttpResponseMessage" /> subject
+	///     is equal to the <paramref name="expected" /> value.
+	/// </summary>
+	public static AndOrResult<HttpResponseMessage?, IThat<HttpResponseMessage?>> HasStatusCode(
+		this IThat<HttpResponseMessage?> source,
+		HttpStatusCode? expected)
+		=> new(source.ThatIs().ExpectationBuilder.AddConstraint((it, _) =>
+			new StatusCodeResult.PropertyConstraint(
+				it,
+				expected,
+				m => m.StatusCode,
+				(a, e) => a.Equals(e),
+				$"has status code {Formatter.Format(expected)}")), source);
 }

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -17,6 +17,7 @@ namespace aweXpect
     {
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.StatusCodeResult HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage?, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Net.HttpStatusCode? expected) { }
     }
 }
 namespace aweXpect.Web.ContentProcessors

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -17,6 +17,7 @@ namespace aweXpect
     {
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.StatusCodeResult HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage?, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Net.HttpStatusCode? expected) { }
     }
 }
 namespace aweXpect.Web.ContentProcessors

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.Tests.cs
@@ -1,0 +1,108 @@
+﻿using System.Net;
+using System.Net.Http;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed partial class HasStatusCode
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenFailing_ShouldIncludeRequestInMessage()
+			{
+				HttpResponseMessage subject = ResponseBuilder
+					.WithStatusCode(HttpStatusCode.BadRequest)
+					.WithContent("some content")
+					.WithRequest(HttpMethod.Get, "https://example.com")
+					.WithRequestContent("request content");
+
+				async Task Act()
+					=> await That(subject).HasStatusCode(HttpStatusCode.OK);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has status code 200 OK,
+					             but it had status code 400 BadRequest
+
+					             HTTP-Request:
+					               HTTP/1.1 400 BadRequest
+					               some content
+					               The originating request was:
+					                 GET https://example.com/ HTTP 1.1
+					                 request content
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFailing_ShouldIncludeResponseContentAndStatusCodeInMessage()
+			{
+				HttpResponseMessage subject = ResponseBuilder
+					.WithStatusCode(HttpStatusCode.BadRequest)
+					.WithContent("some content");
+
+				async Task Act()
+					=> await That(subject).HasStatusCode(HttpStatusCode.OK);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has status code 200 OK,
+					             but it had status code 400 BadRequest
+
+					             HTTP-Request:
+					               HTTP/1.1 400 BadRequest
+					               some content
+					               The originating request was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenStatusCodeDiffersFromExpected_ShouldFail()
+			{
+				HttpResponseMessage subject = ResponseBuilder
+					.WithStatusCode(HttpStatusCode.BadRequest);
+
+				async Task Act()
+					=> await That(subject).HasStatusCode(HttpStatusCode.OK);
+
+				await That(Act).Throws<XunitException>();
+			}
+
+			[Theory]
+			[MemberData(nameof(SuccessStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+			[MemberData(nameof(RedirectStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+			[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+			[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
+			public async Task WhenStatusCodeIsExpected_ShouldSucceed(HttpStatusCode statusCode)
+			{
+				HttpStatusCode expected = statusCode;
+				HttpResponseMessage subject = ResponseBuilder
+					.WithStatusCode(statusCode);
+
+				async Task Act()
+					=> await That(subject).HasStatusCode(expected);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpResponseMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasStatusCode(HttpStatusCode.Accepted);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has status code 202 Accepted,
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}


### PR DESCRIPTION
The expectation `.HasStatusCode(HttpStatusCode.OK)` behaves exactly like `.HasStatusCode().EqualTo(HttpStatusCode.OK)`