### PR TITLE
docs: remove incorrect link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ HttpResponseMessage response = await httpClient.GetAsync("https://github.com/awe
 await Expect.That(response).HasContent("*aweXpect*").AsWildcard();
 ```
 
-You can use the same configuration options as when [comparing strings](/docs/expectations/string#equality).
-
 ## Status
 
 You can verify, that the status code of the `HttpResponseMessage`:


### PR DESCRIPTION
Remove an incorrect link from README.md