### PR TITLE
fix: include content headers

### DIFF
--- a/Source/aweXpect.Web/Helpers/HttpResponseMessageFormatter.cs
+++ b/Source/aweXpect.Web/Helpers/HttpResponseMessageFormatter.cs
@@ -26,9 +26,10 @@ internal static class HttpResponseMessageFormatter
 			.Append(response.StatusCode)
 			.AppendLine();
 
-		IContentProcessor[]? contentProcessors = Customize.aweXpect.Web().ContentProcessors.Get();
+		IContentProcessor[] contentProcessors = Customize.aweXpect.Web().ContentProcessors.Get();
 
-		AppendHeaders(messageBuilder, response.Headers, indentation);
+		AppendHeaders(messageBuilder, response.Headers, indentation + indentation);
+		AppendHeaders(messageBuilder, response.Content.Headers, indentation + indentation);
 		await AppendContent(contentProcessors, messageBuilder, response.Content, indentation, cancellationToken);
 
 		HttpRequestMessage? request = response.RequestMessage;
@@ -44,9 +45,10 @@ internal static class HttpResponseMessageFormatter
 				.Append(request.RequestUri).Append(" HTTP ").Append(request.Version)
 				.AppendLine();
 
-			AppendHeaders(messageBuilder, request.Headers, indentation);
+			AppendHeaders(messageBuilder, request.Headers, indentation + indentation + indentation);
 			if (request.Content != null)
 			{
+				AppendHeaders(messageBuilder, request.Content.Headers, indentation + indentation + indentation);
 				await AppendContent(contentProcessors, messageBuilder, request.Content, indentation + indentation,
 					cancellationToken);
 			}
@@ -86,7 +88,7 @@ internal static class HttpResponseMessageFormatter
 		{
 			foreach (string headerValue in header.Value)
 			{
-				messageBuilder.Append(indentation).Append(indentation)
+				messageBuilder.Append(indentation)
 					.Append(header.Key).Append(": ").AppendLine(headerValue);
 			}
 		}

--- a/Tests/aweXpect.Web.Samples.Tests/CommentsTests.cs
+++ b/Tests/aweXpect.Web.Samples.Tests/CommentsTests.cs
@@ -36,6 +36,7 @@ public class CommentsTests(WebApplicationFactory<Program> factory) : IClassFixtu
 
 			             HTTP-Request:
 			               HTTP/1.1 200 OK
+			                 Content-Type: application/json; charset=utf-8
 			               [
 			                 {
 			                   "id": 1,

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContent.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContent.Tests.cs
@@ -30,6 +30,8 @@ public sealed partial class ThatHttpResponseMessage
 
 					             HTTP-Request:
 					               HTTP/1.1 200 OK
+					                 Content-Type: text/plain; charset=utf-8
+					                 Content-Length: 12
 					               some content
 					               The originating request was <null>
 					             """);

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContentType.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContentType.Tests.cs
@@ -45,6 +45,7 @@ public sealed partial class ThatHttpResponseMessage
 
 					             HTTP-Request:
 					               HTTP/1.1 200 OK
+					                 Content-Type: text/other-content-type
 					               some content
 					               The originating request was <null>
 					             """);

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.EqualToTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.EqualToTests.cs
@@ -29,9 +29,11 @@ public sealed partial class ThatHttpResponseMessage
 
 					             HTTP-Request:
 					               HTTP/1.1 400 BadRequest
+					                 Content-Type: text/plain; charset=utf-8
 					               some content
 					               The originating request was:
 					                 GET https://example.com/ HTTP 1.1
+					                   Content-Type: text/plain; charset=utf-8
 					                 request content
 					             """);
 			}
@@ -54,6 +56,7 @@ public sealed partial class ThatHttpResponseMessage
 
 					             HTTP-Request:
 					               HTTP/1.1 400 BadRequest
+					                 Content-Type: text/plain; charset=utf-8
 					               some content
 					               The originating request was <null>
 					             """);

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.Tests.cs
@@ -29,9 +29,11 @@ public sealed partial class ThatHttpResponseMessage
 
 					             HTTP-Request:
 					               HTTP/1.1 400 BadRequest
+					                 Content-Type: text/plain; charset=utf-8
 					               some content
 					               The originating request was:
 					                 GET https://example.com/ HTTP 1.1
+					                   Content-Type: text/plain; charset=utf-8
 					                 request content
 					             """);
 			}
@@ -54,6 +56,7 @@ public sealed partial class ThatHttpResponseMessage
 
 					             HTTP-Request:
 					               HTTP/1.1 400 BadRequest
+					                 Content-Type: text/plain; charset=utf-8
 					               some content
 					               The originating request was <null>
 					             """);

--- a/Tests/aweXpect.Web.Tests/Web/ContentProcessor.BinaryContentProcessorTests.cs
+++ b/Tests/aweXpect.Web.Tests/Web/ContentProcessor.BinaryContentProcessorTests.cs
@@ -24,6 +24,7 @@ public sealed partial class ContentProcessor
 
 				             HTTP-Request:
 				               HTTP/1.1 200 OK
+				                 Content-Type: text/css
 				               foo
 				               The originating request was <null>
 				             """);
@@ -56,6 +57,7 @@ public sealed partial class ContentProcessor
 
 				               HTTP-Request:
 				                 HTTP/1.1 200 OK
+				                   Content-Type: {{contentType}}
 				                 *Content is binary ({{contentType}}) with length {{bytes.Length}}*
 				                 The originating request was <null>
 				               """);

--- a/Tests/aweXpect.Web.Tests/Web/ContentProcessor.JsonContentProcessorTests.cs
+++ b/Tests/aweXpect.Web.Tests/Web/ContentProcessor.JsonContentProcessorTests.cs
@@ -22,17 +22,18 @@ public sealed partial class ContentProcessor
 				=> await That(httpResponse).HasStatusCode().EqualTo(HttpStatusCode.Accepted);
 
 			await That(Act).Throws<XunitException>()
-				.WithMessage("""
-				             Expected that httpResponse
-				             has status code 202 Accepted,
-				             but it had status code 200 OK
+				.WithMessage($$"""
+				               Expected that httpResponse
+				               has status code 202 Accepted,
+				               but it had status code 200 OK
 
-				             HTTP-Request:
-				               HTTP/1.1 200 OK
-				               {"my-content":1
-				               *** JSON parse error: '1' is an invalid end of a number. Expected a delimiter. LineNumber: 0 | BytePositionInLine: 15. ***
-				               The originating request was <null>
-				             """);
+				               HTTP-Request:
+				                 HTTP/1.1 200 OK
+				                   Content-Type: {{contentType}}
+				                 {"my-content":1
+				                 *** JSON parse error: '1' is an invalid end of a number. Expected a delimiter. LineNumber: 0 | BytePositionInLine: 15. ***
+				                 The originating request was <null>
+				               """);
 		}
 
 		[Theory]
@@ -49,18 +50,19 @@ public sealed partial class ContentProcessor
 				=> await That(httpResponse).HasStatusCode().EqualTo(HttpStatusCode.Accepted);
 
 			await That(Act).Throws<XunitException>()
-				.WithMessage("""
-				             Expected that httpResponse
-				             has status code 202 Accepted,
-				             but it had status code 200 OK
+				.WithMessage($$"""
+				               Expected that httpResponse
+				               has status code 202 Accepted,
+				               but it had status code 200 OK
 
-				             HTTP-Request:
-				               HTTP/1.1 200 OK
-				               {
-				                 "my-content": 1
-				               }
-				               The originating request was <null>
-				             """);
+				               HTTP-Request:
+				                 HTTP/1.1 200 OK
+				                   Content-Type: {{contentType}}
+				                 {
+				                   "my-content": 1
+				                 }
+				                 The originating request was <null>
+				               """);
 		}
 	}
 }

--- a/Tests/aweXpect.Web.Tests/Web/ContentProcessor.StringContentProcessorTests.cs
+++ b/Tests/aweXpect.Web.Tests/Web/ContentProcessor.StringContentProcessorTests.cs
@@ -27,16 +27,17 @@ public sealed partial class ContentProcessor
 					=> await That(httpResponse).HasStatusCode().EqualTo(HttpStatusCode.Accepted);
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that httpResponse
-					             has status code 202 Accepted,
-					             but it had status code 200 OK
+					.WithMessage($$"""
+					               Expected that httpResponse
+					               has status code 202 Accepted,
+					               but it had status code 200 OK
 
-					             HTTP-Request:
-					               HTTP/1.1 200 OK
-					               {"my-content":1}
-					               The originating request was <null>
-					             """);
+					               HTTP-Request:
+					                 HTTP/1.1 200 OK
+					                   Content-Type: {{contentType}}
+					                 {"my-content":1}
+					                 The originating request was <null>
+					               """);
 			}
 		}
 
@@ -62,6 +63,7 @@ public sealed partial class ContentProcessor
 
 				             HTTP-Request:
 				               HTTP/1.1 200 OK
+				                 Content-Type: text/css
 				               body {
 				                   background-color: powderblue;
 				               }
@@ -86,16 +88,17 @@ public sealed partial class ContentProcessor
 				=> await That(httpResponse).HasStatusCode().EqualTo(HttpStatusCode.Accepted);
 
 			await That(Act).Throws<XunitException>()
-				.WithMessage("""
-				             Expected that httpResponse
-				             has status code 202 Accepted,
-				             but it had status code 200 OK
+				.WithMessage($$"""
+				               Expected that httpResponse
+				               has status code 202 Accepted,
+				               but it had status code 200 OK
 
-				             HTTP-Request:
-				               HTTP/1.1 200 OK
-				               {"my-content":1}
-				               The originating request was <null>
-				             """);
+				               HTTP-Request:
+				                 HTTP/1.1 200 OK
+				                   Content-Type: {{contentType}}
+				                 {"my-content":1}
+				                 The originating request was <null>
+				               """);
 		}
 	}
 }

--- a/Tests/aweXpect.Web.Tests/Web/ContentProcessor.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/Web/ContentProcessor.Tests.cs
@@ -28,6 +28,7 @@ public sealed partial class ContentProcessor
 
 				             HTTP-Request:
 				               HTTP/1.1 200 OK
+				                 Content-Type: application/my-type
 				               *Content (application/my-type) with length 0*
 				               The originating request was <null>
 				             """);
@@ -50,6 +51,7 @@ public sealed partial class ContentProcessor
 
 				             HTTP-Request:
 				               HTTP/1.1 200 OK
+				                 Content-Type: application/my-type
 				               *Content (application/my-type) with length 0*
 				               The originating request was <null>
 				             """);


### PR DESCRIPTION
Include headers of `HttpContent` in the formatted output message and use correct indentation for headers.