### PR TITLE
feat: add `HasHeader` expectations

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -2,8 +2,43 @@
 
 Expectations for `HttpClient`.
 
-
 ## `HttpResponseMessage`
+
+### Status
+
+You can verify the status code of the `HttpResponseMessage`:
+
+```csharp
+HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");
+await Expect.That(response).HasStatusCode().Success();
+await Expect.That(response).HasStatusCode(HttpStatusCode.OK);
+
+response = await httpClient.PostAsync("https://github.com/aweXpect/aweXpect.Web", new StringContent(""));
+await Expect.That(response).HasStatusCode().ClientError().Or.HasStatusCode().ServerError().Or.HasStatusCode().Redirection();
+```
+
+### Header
+
+You can verify the headers of the `HttpResponseMessage`:
+
+```csharp
+HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");
+
+await Expect.That(response).HasHeader("X-GitHub-Request-Id");
+await Expect.That(response).HasHeader("Cache-Control")
+    .WithValue("must-revalidate, max-age=0, private");
+```
+
+You can also add additional expectations on the header value(s):
+
+```csharp
+HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");
+
+await Expect.That(response).HasHeader("X-GitHub-Request-Id")
+    .WhoseValue(value => value.IsNotEmpty());
+await Expect.That(response).HasHeader("Vary")
+    .WhoseValues(values => values.Contains("Turbo-Frame"));
+```
 
 ### Content
 
@@ -16,19 +51,6 @@ await Expect.That(response).HasContent("*aweXpect*").AsWildcard();
 ```
 
 You can use the same configuration options as when [comparing strings](/docs/expectations/string#equality).
-
-### Status code
-
-You can verify, that the status code of the `HttpResponseMessage`:
-
-```csharp
-HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect");
-await Expect.That(response).HasStatusCode().Success();
-await Expect.That(response).HasStatusCode(HttpStatusCode.OK);
-
-response = await httpClient.PostAsync("https://github.com/aweXpect/aweXpect", new StringContent(""));
-await Expect.That(response).HasStatusCode().ClientError().Or.HasStatusCode().ServerError().Or.HasStatusCode().Redirection();
-```
 
 Great care was taken to provide as much information as possible, when a status verification failed.  
 The response could look similar to:
@@ -48,4 +70,3 @@ The response could look similar to:
 >   The originating request was:
 >     GET https://github.com/aweXpect/missing-repo HTTP 1.1
 > ```
-

--- a/README.md
+++ b/README.md
@@ -8,6 +8,44 @@
 
 Web extensions for [aweXpect](https://github.com/aweXpect/aweXpect).
 
+## Status
+
+You can verify the status code of the `HttpResponseMessage`:
+
+```csharp
+HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");
+await Expect.That(response).HasStatusCode().Success();
+await Expect.That(response).HasStatusCode(HttpStatusCode.OK);
+
+response = await httpClient.PostAsync("https://github.com/aweXpect/aweXpect.Web", new StringContent(""));
+await Expect.That(response).HasStatusCode().ClientError().Or.HasStatusCode().ServerError().Or.HasStatusCode().Redirection();
+```
+
+
+## Header
+
+You can verify the headers of the `HttpResponseMessage`:
+
+```csharp
+HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");
+
+await Expect.That(response).HasHeader("X-GitHub-Request-Id");
+await Expect.That(response).HasHeader("Cache-Control")
+    .WithValue("must-revalidate, max-age=0, private");
+```
+
+You can also add additional expectations on the header value(s):
+
+```csharp
+HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");
+
+await Expect.That(response).HasHeader("X-GitHub-Request-Id")
+    .WhoseValue(value => value.IsNotEmpty());
+await Expect.That(response).HasHeader("Vary")
+    .WhoseValues(values => values.Contains("Turbo-Frame"));
+```
+
+
 ## Content
 
 You can verify, the content of the `HttpResponseMessage`:
@@ -18,18 +56,6 @@ HttpResponseMessage response = await httpClient.GetAsync("https://github.com/awe
 await Expect.That(response).HasContent("*aweXpect*").AsWildcard();
 ```
 
-## Status
-
-You can verify, that the status code of the `HttpResponseMessage`:
-
-```csharp
-HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect");
-await Expect.That(response).HasStatusCode().Success();
-await Expect.That(response).HasStatusCode().EqualTo(HttpStatusCode.OK);
-
-response = await httpClient.PostAsync("https://github.com/aweXpect/aweXpect", new StringContent(""));
-await Expect.That(response).HasStatusCode().ClientError().Or.HasStatusCode().ServerError().Or.HasStatusCode().Redirection();
-```
 
 Great care was taken to provide as much information as possible, when a status verification failed.  
 The response could look similar to:

--- a/Source/aweXpect.Web/HasHeaderValueResult.cs
+++ b/Source/aweXpect.Web/HasHeaderValueResult.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+/// <summary>
+///     The result on a header value.
+/// </summary>
+/// <remarks>
+///     <seealso cref="AndOrResult{TType,TThat}" />
+/// </remarks>
+public class HasHeaderValueResult<TType, TThat>
+	: AndOrResult<TType, TThat>
+{
+	private readonly ExpectationBuilder _expectationBuilder;
+	private readonly Func<TType, string?[]?> _headerValueAccessor;
+	private readonly TThat _returnValue;
+
+	internal HasHeaderValueResult(
+		ExpectationBuilder expectationBuilder,
+		TThat returnValue,
+		Func<TType, string?[]?> headerValueAccessor)
+		: base(expectationBuilder, returnValue)
+	{
+		_expectationBuilder = expectationBuilder;
+		_returnValue = returnValue;
+		_headerValueAccessor = headerValueAccessor;
+	}
+
+	/// <summary>
+	///     Verifies that the header has the <paramref name="expected" /> value.
+	/// </summary>
+	public StringEqualityResult<TType, TThat> WithValue(string? expected)
+	{
+		StringEqualityOptions options = new();
+		_expectationBuilder.And("").AddConstraint((_, _) =>
+			new WithHeaderValueConstraint("the value", expected, _headerValueAccessor, options));
+		return new StringEqualityResult<TType, TThat>(_expectationBuilder, _returnValue, options);
+	}
+
+	/// <summary>
+	///     Verifies that the header value satisfies the <paramref name="expectations" />.
+	/// </summary>
+	public AndOrResult<TType, TThat> WhoseValue(
+		Action<IThat<string?>> expectations)
+	{
+		_expectationBuilder
+			.ForMember(
+				MemberAccessor<TType, string?>.FromFunc(t =>
+				{
+					string?[]? values = _headerValueAccessor(t);
+					if (values?.Length != 1)
+					{
+						return null;
+					}
+
+					return values[0];
+				}, "the value "),
+				(member, stringBuilder) => stringBuilder.Append(" whose value "))
+			.AddExpectations(e => expectations(new ThatSubject<string?>(e)));
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies that the header values satisfies the <paramref name="expectations" />.
+	/// </summary>
+	public AndOrResult<TType, TThat> WhoseValues(
+		Action<IThat<string?[]?>> expectations)
+	{
+		_expectationBuilder
+			.ForMember(
+				MemberAccessor<TType, string?[]?>.FromFunc(t => _headerValueAccessor(t), "the values "),
+				(member, stringBuilder) => stringBuilder.Append(" whose values "))
+			.AddExpectations(e => expectations(new ThatSubject<string?[]>(e)), ExpectationGrammars.Nested);
+		return this;
+	}
+
+	private readonly struct WithHeaderValueConstraint(
+		string it,
+		string? expected,
+		Func<TType, string?[]?> headerValueAccessor,
+		StringEqualityOptions options)
+		: IValueConstraint<TType?>
+	{
+		public ConstraintResult IsMetBy(TType? actual)
+		{
+			if (actual is null)
+			{
+				return new ConstraintResult.Failure<TType?>(actual, ToString(), "");
+			}
+
+			string?[]? headerValues = headerValueAccessor(actual);
+			if (headerValues is null)
+			{
+				return new ConstraintResult.Failure<TType?>(actual, ToString(),
+					$"{it} did not contain the expected header");
+			}
+
+			if (headerValues.Length != 1)
+			{
+				return new ConstraintResult.Failure<TType?>(actual, ToString(),
+					$"the header contained {headerValues.Length} values");
+			}
+
+			string? headerValue = headerValues[0];
+			if (options.AreConsideredEqual(headerValue, expected))
+			{
+				return new ConstraintResult.Success<TType?>(actual, ToString());
+			}
+
+			return new ConstraintResult.Failure(ToString(),
+				options.GetExtendedFailure(it, headerValue, expected));
+		}
+
+		public override string ToString()
+			=> $" whose value {options.GetExpectation(expected, ExpectationGrammars.Active)}";
+	}
+}

--- a/Source/aweXpect.Web/HasHeaderValueResult.cs
+++ b/Source/aweXpect.Web/HasHeaderValueResult.cs
@@ -65,7 +65,7 @@ public class HasHeaderValueResult<TType, TThat>
 	}
 
 	/// <summary>
-	///     Verifies that the header values satisfies the <paramref name="expectations" />.
+	///     Verifies that the header values satisfy the <paramref name="expectations" />.
 	/// </summary>
 	public AndOrResult<TType, TThat> WhoseValues(
 		Action<IThat<string?[]?>> expectations)

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasHeader.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasHeader.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+
+namespace aweXpect;
+
+public static partial class ThatHttpResponseMessage
+{
+	/// <summary>
+	///     Verifies that the <see cref="HttpResponseMessage" /> has the <paramref name="expected" /> header.
+	/// </summary>
+	public static HasHeaderValueResult<HttpResponseMessage, IThat<HttpResponseMessage?>> HasHeader(
+		this IThat<HttpResponseMessage?> source,
+		string expected)
+		=> new(source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
+				new HasHeaderConstraint(it, expected)),
+			source,
+			a => a.Headers.TryGetValues(expected, out IEnumerable<string>? values) ? values.ToArray() : null);
+
+	private readonly struct HasHeaderConstraint(string it, string expected)
+		: IAsyncConstraint<HttpResponseMessage>
+	{
+		public async Task<ConstraintResult> IsMetBy(
+			HttpResponseMessage? actual,
+			CancellationToken cancellationToken)
+		{
+			if (actual == null)
+			{
+				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+					$"{it} was <null>", FurtherProcessingStrategy.IgnoreResult);
+			}
+
+			if (actual.Headers.TryGetValues(expected, out _))
+			{
+				return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());
+			}
+
+			string formattedResponse =
+				await HttpResponseMessageFormatter.Format(actual, "  ", cancellationToken);
+			return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+					$"{it} did not contain the expected header", FurtherProcessingStrategy.IgnoreResult)
+				.WithContext("HTTP-Request", formattedResponse);
+		}
+
+		public override string ToString()
+			=> $"has a `{expected}` header";
+	}
+}

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -2,6 +2,12 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace aweXpect
 {
+    public class HasHeaderValueResult<TType, TThat> : aweXpect.Results.AndOrResult<TType, TThat>
+    {
+        public aweXpect.Results.AndOrResult<TType, TThat> WhoseValue(System.Action<aweXpect.Core.IThat<string?>> expectations) { }
+        public aweXpect.Results.AndOrResult<TType, TThat> WhoseValues(System.Action<aweXpect.Core.IThat<string?[]?>> expectations) { }
+        public aweXpect.Results.StringEqualityResult<TType, TThat> WithValue(string? expected) { }
+    }
     public class StatusCodeResult
     {
         public StatusCodeResult(aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Func<System.Net.Http.HttpResponseMessage, System.Net.HttpStatusCode> mapper) { }
@@ -17,6 +23,7 @@ namespace aweXpect
     {
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContentType(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
+        public static aweXpect.HasHeaderValueResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasHeader(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.StatusCodeResult HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage?, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Net.HttpStatusCode? expected) { }
     }

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -2,6 +2,12 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace aweXpect
 {
+    public class HasHeaderValueResult<TType, TThat> : aweXpect.Results.AndOrResult<TType, TThat>
+    {
+        public aweXpect.Results.AndOrResult<TType, TThat> WhoseValue(System.Action<aweXpect.Core.IThat<string?>> expectations) { }
+        public aweXpect.Results.AndOrResult<TType, TThat> WhoseValues(System.Action<aweXpect.Core.IThat<string?[]?>> expectations) { }
+        public aweXpect.Results.StringEqualityResult<TType, TThat> WithValue(string? expected) { }
+    }
     public class StatusCodeResult
     {
         public StatusCodeResult(aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Func<System.Net.Http.HttpResponseMessage, System.Net.HttpStatusCode> mapper) { }
@@ -17,6 +23,7 @@ namespace aweXpect
     {
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContentType(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
+        public static aweXpect.HasHeaderValueResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasHeader(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.StatusCodeResult HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage?, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Net.HttpStatusCode? expected) { }
     }

--- a/Tests/aweXpect.Web.Tests/TestHelpers/HttpResponseBuilder.cs
+++ b/Tests/aweXpect.Web.Tests/TestHelpers/HttpResponseBuilder.cs
@@ -85,6 +85,7 @@ internal sealed class HttpResponseBuilder
 		{
 			httpResponseMessage.Headers.Add(header.Key, header.Value);
 		}
+
 		foreach (KeyValuePair<string, string[]> header in _multiHeaders)
 		{
 			httpResponseMessage.Headers.Add(header.Key, header.Value);

--- a/Tests/aweXpect.Web.Tests/TestHelpers/HttpResponseBuilder.cs
+++ b/Tests/aweXpect.Web.Tests/TestHelpers/HttpResponseBuilder.cs
@@ -9,6 +9,7 @@ namespace aweXpect.Web.Tests.TestHelpers;
 internal sealed class HttpResponseBuilder
 {
 	private readonly Dictionary<string, string> _headers = new();
+	private readonly Dictionary<string, string[]> _multiHeaders = new();
 	private HttpContent? _content;
 	private string? _contentType;
 	private HttpRequestBuilder? _requestBuilder;
@@ -46,6 +47,12 @@ internal sealed class HttpResponseBuilder
 		return this;
 	}
 
+	public HttpResponseBuilder WithHeaders(string name, params string[] values)
+	{
+		_multiHeaders.Add(name, values);
+		return this;
+	}
+
 	public HttpResponseBuilder WithContentType(string mediaType)
 	{
 		_contentType = mediaType;
@@ -75,6 +82,10 @@ internal sealed class HttpResponseBuilder
 		}
 
 		foreach (KeyValuePair<string, string> header in _headers)
+		{
+			httpResponseMessage.Headers.Add(header.Key, header.Value);
+		}
+		foreach (KeyValuePair<string, string[]> header in _multiHeaders)
 		{
 			httpResponseMessage.Headers.Add(header.Key, header.Value);
 		}

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.Tests.cs
@@ -1,0 +1,89 @@
+﻿using System.IO;
+using System.Net.Http;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed partial class HasHeader
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenContentTypeHeaderIsNotSet_ShouldFail()
+			{
+				string expected = "text/content-type";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContent(new StreamContent(new MemoryStream([0x0, 0x1,])));
+
+				async Task Act()
+					=> await That(subject).HasContentType(expected);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `Content-Type` header equal to "text/content-type",
+					             but it had no `Content-Type` header
+
+					             HTTP-Request:
+					               HTTP/1.1 200 OK
+					               *Content with length 2*
+					               The originating request was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenHeaderDoesNotExist_ShouldFail()
+			{
+				string name = "x-my-header";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContent("some content");
+
+				async Task Act()
+					=> await That(subject).HasHeader(name);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-my-header` header,
+					             but it did not contain the expected header
+
+					             HTTP-Request:
+					               HTTP/1.1 200 OK
+					                 Content-Type: text/plain; charset=utf-8
+					               some content
+					               The originating request was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenHeaderExists_ShouldSucceed()
+			{
+				string name = "x-my-header";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeader(name, "some header");
+
+				async Task Act()
+					=> await That(subject).HasHeader(name);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpResponseMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasHeader("x-my-header");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-my-header` header,
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WhoseValueTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WhoseValueTests.cs
@@ -1,0 +1,93 @@
+﻿using System.Net.Http;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed partial class HasHeader
+	{
+		public sealed class WhoseValueTests
+		{
+			[Fact]
+			public async Task WhenHeaderDoesNotExist_ShouldFail()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				string otherKey = "x-some-other-key";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject).HasHeader(otherKey).WhoseValue(v => v.IsEqualTo(value));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-some-other-key` header whose value is equal to "some header",
+					             but it did not contain the expected header and the value was <null>
+
+					             HTTP-Request:
+					               HTTP/1.1 200 OK
+					                 x-my-header: some header
+					                 Content-Type: text/plain; charset=utf-8
+					               
+					               The originating request was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenHeaderExistsAndValueDoesNotSatisfyTheExpectations_ShouldFail()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				string expectedValue = "some other header";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject).HasHeader(name).WhoseValue(v => v.IsEqualTo(expectedValue));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-my-header` header whose value is equal to "some other header",
+					             but the value was "some header" which differs at index 5:
+					                     ↓ (actual)
+					               "some header"
+					               "some other header"
+					                     ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenHeaderExistsAndValueSatisfiesTheExpectations_ShouldSucceed()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject).HasHeader(name).WhoseValue(v => v.IsEqualTo(value));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpResponseMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasHeader("x-my-key").WhoseValue(v => v.IsEmpty());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-my-key` header whose value is empty,
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WhoseValuesTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WhoseValuesTests.cs
@@ -1,0 +1,93 @@
+﻿using System.Net.Http;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed partial class HasHeader
+	{
+		public sealed class WhoseValuesTests
+		{
+			[Fact]
+			public async Task WhenHeaderDoesNotExist_ShouldFail()
+			{
+				string name = "x-my-header";
+				string[] value = ["foo", "bar", "baz",];
+				string otherKey = "x-some-other-key";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeaders(name, value);
+
+				async Task Act()
+					=> await That(subject).HasHeader(otherKey).WhoseValues(v => v.HasCount().EqualTo(3));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-some-other-key` header whose values has exactly 3 items,
+					             but it did not contain the expected header and the values was <null>
+
+					             HTTP-Request:
+					               HTTP/1.1 200 OK
+					                 x-my-header: foo
+					                 x-my-header: bar
+					                 x-my-header: baz
+					                 Content-Type: text/plain; charset=utf-8
+					               
+					               The originating request was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenHeaderExistsAndValueDoesNotSatisfyTheExpectations_ShouldFail()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				string expectedValue = "some other header";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject).HasHeader(name).WhoseValues(v => v.Contains(expectedValue));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-my-header` header whose values contains "some other header" at least once,
+					             but the values contained it 0 times in [
+					               "some header"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenHeaderExistsAndValueSatisfiesTheExpectations_ShouldSucceed()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject).HasHeader(name).WhoseValues(v => v.Contains(value));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpResponseMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasHeader("x-my-key").WhoseValues(v => v.IsEmpty());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-my-key` header whose values are empty,
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WithValueTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WithValueTests.cs
@@ -1,0 +1,93 @@
+﻿using System.Net.Http;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatHttpResponseMessage
+{
+	public sealed partial class HasHeader
+	{
+		public sealed class WithValueTests
+		{
+			[Fact]
+			public async Task WhenHeaderDoesNotExist_ShouldFail()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				string otherKey = "x-some-other-key";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject).HasHeader(otherKey).WithValue(value);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-some-other-key` header whose value is equal to "some header",
+					             but it did not contain the expected header
+
+					             HTTP-Request:
+					               HTTP/1.1 200 OK
+					                 x-my-header: some header
+					                 Content-Type: text/plain; charset=utf-8
+					               
+					               The originating request was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenHeaderExistsAndValueDoesNotSatisfyTheExpectations_ShouldFail()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				string expectedValue = "some other header";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject).HasHeader(name).WithValue(expectedValue);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-my-header` header whose value is equal to "some other header",
+					             but the value was "some header" which differs at index 5:
+					                     ↓ (actual)
+					               "some header"
+					               "some other header"
+					                     ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenHeaderExistsAndValueSatisfiesTheExpectations_ShouldSucceed()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject).HasHeader(name).WithValue(value);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpResponseMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasHeader("x-my-key").WithValue("foo");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-my-key` header whose value is equal to "foo",
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}


### PR DESCRIPTION
You can verify the headers of the `HttpResponseMessage`:

```csharp
HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");

await Expect.That(response).HasHeader("X-GitHub-Request-Id");
await Expect.That(response).HasHeader("Cache-Control")
    .WithValue("must-revalidate, max-age=0, private");
```

You can also add additional expectations on the header value(s):

```csharp
HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");

await Expect.That(response).HasHeader("X-GitHub-Request-Id")
    .WhoseValue(value => value.IsNotEmpty());
await Expect.That(response).HasHeader("Vary")
    .WhoseValues(values => values.Contains("Turbo-Frame"));
```