### PR TITLE
feat: add `HasContent` with expectations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="1.1.0"/>
+		<PackageVersion Include="aweXpect" Version="1.2.0"/>
 		<PackageVersion Include="aweXpect.Core" Version="1.2.0"/>
 		<PackageVersion Include="aweXpect.Json" Version="0.3.0"/>
 		<PackageVersion Include="System.Net.Http" Version="4.3.4"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="1.0.1"/>
-		<PackageVersion Include="aweXpect.Core" Version="1.0.1"/>
+		<PackageVersion Include="aweXpect" Version="1.1.0"/>
+		<PackageVersion Include="aweXpect.Core" Version="1.2.0"/>
 		<PackageVersion Include="aweXpect.Json" Version="0.3.0"/>
 		<PackageVersion Include="System.Net.Http" Version="4.3.4"/>
 		<PackageVersion Include="System.Text.Json" Version="9.0.2"/>

--- a/Source/aweXpect.Web/Helpers/HttpResponseMessageFormatter.cs
+++ b/Source/aweXpect.Web/Helpers/HttpResponseMessageFormatter.cs
@@ -14,10 +14,15 @@ namespace aweXpect.Helpers;
 internal static class HttpResponseMessageFormatter
 {
 	public static async Task<string> Format(
-		HttpResponseMessage response,
+		HttpResponseMessage? response,
 		string indentation,
 		CancellationToken cancellationToken)
 	{
+		if (response == null)
+		{
+			return "<null>";
+		}
+
 		StringBuilder messageBuilder = new();
 
 		messageBuilder.Append(indentation)

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -21,6 +21,7 @@ namespace aweXpect
     }
     public static class ThatHttpResponseMessage
     {
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Action<aweXpect.Core.IThat<string?>> expectations) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContentType(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.HasHeaderValueResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasHeader(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -21,6 +21,7 @@ namespace aweXpect
     }
     public static class ThatHttpResponseMessage
     {
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Action<aweXpect.Core.IThat<string?>> expectations) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContentType(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.HasHeaderValueResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasHeader(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }

--- a/Tests/aweXpect.Web.Samples.Tests/CommentsTests.cs
+++ b/Tests/aweXpect.Web.Samples.Tests/CommentsTests.cs
@@ -20,6 +20,28 @@ public class CommentsTests(WebApplicationFactory<Program> factory) : IClassFixtu
 	}
 
 	[Fact]
+	public async Task GetComments_ShouldReturnExpectedBody()
+	{
+		HttpClient client = factory.CreateClient();
+
+		HttpResponseMessage response = await client.GetAsync("/comments");
+
+		await Expect.That(response).HasContent(which =>
+			which.IsValidJsonMatching([
+				new
+				{
+					author = "Valentin",
+					body = "This is my first example comment",
+				},
+				new
+				{
+					author = "Breuß",
+					body = "Another comment (my second)",
+				},
+			]));
+	}
+
+	[Fact]
 	public async Task GetComments_WhenCheckingForInvalidStatusCode_ShouldHaveCorrectFailureMessage()
 	{
 		HttpClient client = factory.CreateClient();

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContent.ExpectationsTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContent.ExpectationsTests.cs
@@ -6,7 +6,7 @@ public sealed partial class ThatHttpResponseMessage
 {
 	public sealed partial class HasContent
 	{
-		public sealed class Tests
+		public sealed class ExpectationsTests
 		{
 			[Fact]
 			public async Task WhenContentDiffersFromExpected_ShouldFail()
@@ -16,13 +16,13 @@ public sealed partial class ThatHttpResponseMessage
 					.WithContent("some content");
 
 				async Task Act()
-					=> await That(subject).HasContent(expected);
+					=> await That(subject).HasContent(which => which.IsEqualTo(expected));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a string content equal to "other content",
-					             but it was "some content" which differs at index 0:
+					             has a string content which is equal to "other content",
+					             but the string content was "some content" which differs at index 0:
 					                ↓ (actual)
 					               "some content"
 					               "other content"
@@ -45,7 +45,7 @@ public sealed partial class ThatHttpResponseMessage
 					.WithContent(expected);
 
 				async Task Act()
-					=> await That(subject).HasContent(expected);
+					=> await That(subject).HasContent(which => which.IsEqualTo(expected));
 
 				await That(Act).DoesNotThrow();
 			}
@@ -56,13 +56,16 @@ public sealed partial class ThatHttpResponseMessage
 				HttpResponseMessage? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasContent("some content");
+					=> await That(subject).HasContent(which => which.IsEmpty());
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a string content equal to "some content",
+					             has a string content which is empty,
 					             but it was <null>
+					             
+					             HTTP-Request:
+					             <null>
 					             """);
 			}
 		}


### PR DESCRIPTION
Add an overload of `HasContent` that accepts an `Action<IThat<string?>> expectations` parameter to specify expectations on the string content.