### PR TITLE
feat: add `DoesNotHaveHeader`

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -27,6 +27,8 @@ HttpResponseMessage response = await httpClient.GetAsync("https://github.com/awe
 await Expect.That(response).HasHeader("X-GitHub-Request-Id");
 await Expect.That(response).HasHeader("Cache-Control")
     .WithValue("must-revalidate, max-age=0, private");
+
+await Expect.That(response).DoesNotHaveHeader("X-My-Header");
 ```
 
 You can also add additional expectations on the header value(s):

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ HttpResponseMessage response = await httpClient.GetAsync("https://github.com/awe
 await Expect.That(response).HasHeader("X-GitHub-Request-Id");
 await Expect.That(response).HasHeader("Cache-Control")
     .WithValue("must-revalidate, max-age=0, private");
+
+await Expect.That(response).DoesNotHaveHeader("X-My-Header");
 ```
 
 You can also add additional expectations on the header value(s):

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -4,6 +4,7 @@ namespace aweXpect
 {
     public static class ThatHttpResponseMessage
     {
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> DoesNotHaveHeader(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string unexpected) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Action<aweXpect.Core.IThat<string?>> expectations) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContentType(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -4,6 +4,7 @@ namespace aweXpect
 {
     public static class ThatHttpResponseMessage
     {
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> DoesNotHaveHeader(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string unexpected) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Action<aweXpect.Core.IThat<string?>> expectations) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasContentType(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string expected) { }

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.DoesNotHaveHeader.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.DoesNotHaveHeader.Tests.cs
@@ -1,49 +1,50 @@
-﻿using System.IO;
-using System.Net.Http;
+﻿using System.Net.Http;
 
 namespace aweXpect.Tests;
 
 public sealed partial class ThatHttpResponseMessage
 {
-	public sealed partial class HasHeader
+	public sealed class DoesNotHaveHeader
 	{
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenHeaderDoesNotExist_ShouldFail()
+			public async Task WhenHeaderDoesNotExist_ShouldSucceed()
 			{
 				string name = "x-my-header";
 				HttpResponseMessage subject = ResponseBuilder
 					.WithContent("some content");
 
 				async Task Act()
-					=> await That(subject).HasHeader(name);
+					=> await That(subject).DoesNotHaveHeader(name);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenHeaderExists_ShouldFail()
+			{
+				string name = "x-my-header";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeader(name, "some header")
+					.WithContent("some content");
+
+				async Task Act()
+					=> await That(subject).DoesNotHaveHeader(name);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a `x-my-header` header,
-					             but it did not contain the expected header
+					             does not have a `x-my-header` header,
+					             but it did contain the `x-my-header` header: ["some header"]
 
 					             HTTP-Request:
 					               HTTP/1.1 200 OK
+					                 x-my-header: some header
 					                 Content-Type: text/plain; charset=utf-8
 					               some content
 					               The originating request was <null>
 					             """);
-			}
-
-			[Fact]
-			public async Task WhenHeaderExists_ShouldSucceed()
-			{
-				string name = "x-my-header";
-				HttpResponseMessage subject = ResponseBuilder
-					.WithHeader(name, "some header");
-
-				async Task Act()
-					=> await That(subject).HasHeader(name);
-
-				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -52,12 +53,12 @@ public sealed partial class ThatHttpResponseMessage
 				HttpResponseMessage? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasHeader("x-my-header");
+					=> await That(subject).DoesNotHaveHeader("x-my-header");
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a `x-my-header` header,
+					             does not have a `x-my-header` header,
 					             but it was <null>
 					             """);
 			}


### PR DESCRIPTION
Add expectation that an unexpected header does not exist:
```csharp
await Expect.That(response).DoesNotHaveHeader("X-My-Header");
```

*Fixes #31*