### PR TITLE
feat: add expectations for `HttpRequestMessage`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="1.2.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="1.2.0"/>
+		<PackageVersion Include="aweXpect" Version="1.3.0"/>
+		<PackageVersion Include="aweXpect.Core" Version="1.3.0"/>
 		<PackageVersion Include="aweXpect.Json" Version="0.4.0"/>
 		<PackageVersion Include="System.Net.Http" Version="4.3.4"/>
 		<PackageVersion Include="System.Text.Json" Version="9.0.2"/>

--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -2,7 +2,6 @@
 
 Expectations for `HttpClient`.
 
-
 ## `HttpRequestMessage`
 
 ### Header
@@ -45,8 +44,8 @@ var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/aweXpe
 await Expect.That(request).HasContent("*aweXpect*").AsWildcard();
 ```
 
-You can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
-
+You can use the same configuration options as
+when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
 
 ## `HttpResponseMessage`
 
@@ -98,7 +97,8 @@ HttpResponseMessage response = await httpClient.GetAsync("https://github.com/awe
 await Expect.That(response).HasContent("*aweXpect*").AsWildcard();
 ```
 
-You can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
+You can use the same configuration options as
+when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
 
 Great care was taken to provide as much information as possible, when a status verification failed.  
 The response could look similar to:
@@ -122,7 +122,8 @@ The response could look similar to:
 
 #### Problem Details
 
-You can verify that the content contains a valid [ProblemDetails](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.problemdetails) object:
+You can verify that the content contains a
+valid [ProblemDetails](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.problemdetails) object:
 
 ```csharp
 HttpResponseMessage response = // a call that returns a problem details object
@@ -134,4 +135,5 @@ await Expect.That(response)
     .WithInstance("93c8f977-7ff7-46ed-900f-7b6264624a31");
 ```
 
-For all string values you can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality). 
+For all string values you can use the same configuration options as
+when [comparing strings](https://awexpect.com/docs/expectations/string#equality). 

--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -2,6 +2,52 @@
 
 Expectations for `HttpClient`.
 
+
+## `HttpRequestMessage`
+
+### Header
+
+You can verify the headers of the `HttpRequestMessage`:
+
+```csharp
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+// Add headers
+
+await Expect.That(request).HasHeader("X-GitHub-Request-Id");
+await Expect.That(request).HasHeader("Cache-Control")
+    .WithValue("must-revalidate, max-age=0, private");
+
+await Expect.That(request).DoesNotHaveHeader("X-My-Header");
+```
+
+You can also add additional expectations on the header value(s):
+
+```csharp
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+// Add headers
+
+await Expect.That(request).HasHeader("X-GitHub-Request-Id")
+    .WhoseValue(value => value.IsNotEmpty());
+await Expect.That(request).HasHeader("Vary")
+    .WhoseValues(values => values.Contains("Turbo-Frame"));
+```
+
+### Content
+
+You can verify, the content of the `HttpRequestMessage`:
+
+```csharp
+var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/aweXpect/aweXpect.Web")
+{
+	Content = new StringContent("my aweXpect content")
+};
+
+await Expect.That(request).HasContent("*aweXpect*").AsWildcard();
+```
+
+You can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
+
+
 ## `HttpResponseMessage`
 
 ### Status
@@ -52,7 +98,7 @@ HttpResponseMessage response = await httpClient.GetAsync("https://github.com/awe
 await Expect.That(response).HasContent("*aweXpect*").AsWildcard();
 ```
 
-You can use the same configuration options as when [comparing strings](/docs/expectations/string#equality).
+You can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
 
 Great care was taken to provide as much information as possible, when a status verification failed.  
 The response could look similar to:
@@ -62,15 +108,16 @@ The response could look similar to:
 > but it was 404 NotFound
 > 
 > HTTP-Request:
->   HTTP/1.1 404 NotFound
+>   GET https://github.com/aweXpect/missing-repo HTTP/1.1
+> 
+> HTTP-Response:
+>   404 NotFound HTTP/1.1
 >     Server: GitHub.com
 >     Date: Fri, 29 Nov 2024 07:55:47 GMT
 >     Cache-Control: no-cache
 >     Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
 >     X-GitHub-Request-Id: DB30:24038B:287F716:29D98BD:67497384
 >   Content is binary
->   The originating request was:
->     GET https://github.com/aweXpect/missing-repo HTTP 1.1
 > ```
 
 #### Problem Details

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 Web extensions for [aweXpect](https://github.com/aweXpect/aweXpect).
 
-
 ## `HttpRequestMessage`
 
 ### Header
@@ -51,8 +50,8 @@ var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/aweXpe
 await Expect.That(request).HasContent("*aweXpect*").AsWildcard();
 ```
 
-You can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
-
+You can use the same configuration options as
+when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
 
 ## `HttpResponseMessage`
 
@@ -104,7 +103,8 @@ HttpResponseMessage response = await httpClient.GetAsync("https://github.com/awe
 await Expect.That(response).HasContent("*aweXpect*").AsWildcard();
 ```
 
-You can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
+You can use the same configuration options as
+when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
 
 Great care was taken to provide as much information as possible, when a status verification failed.  
 The response could look similar to:
@@ -128,7 +128,8 @@ The response could look similar to:
 
 #### Problem Details
 
-You can verify that the content contains a valid [ProblemDetails](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.problemdetails) object:
+You can verify that the content contains a
+valid [ProblemDetails](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.problemdetails) object:
 
 ```csharp
 HttpResponseMessage response = // a call that returns a problem details object
@@ -140,4 +141,5 @@ await Expect.That(response)
     .WithInstance("93c8f977-7ff7-46ed-900f-7b6264624a31");
 ```
 
-For all string values you can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality). 
+For all string values you can use the same configuration options as
+when [comparing strings](https://awexpect.com/docs/expectations/string#equality). 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,55 @@
 
 Web extensions for [aweXpect](https://github.com/aweXpect/aweXpect).
 
-## Status
+
+## `HttpRequestMessage`
+
+### Header
+
+You can verify the headers of the `HttpRequestMessage`:
+
+```csharp
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+// Add headers
+
+await Expect.That(request).HasHeader("X-GitHub-Request-Id");
+await Expect.That(request).HasHeader("Cache-Control")
+    .WithValue("must-revalidate, max-age=0, private");
+
+await Expect.That(request).DoesNotHaveHeader("X-My-Header");
+```
+
+You can also add additional expectations on the header value(s):
+
+```csharp
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+// Add headers
+
+await Expect.That(request).HasHeader("X-GitHub-Request-Id")
+    .WhoseValue(value => value.IsNotEmpty());
+await Expect.That(request).HasHeader("Vary")
+    .WhoseValues(values => values.Contains("Turbo-Frame"));
+```
+
+### Content
+
+You can verify, the content of the `HttpRequestMessage`:
+
+```csharp
+var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/aweXpect/aweXpect.Web")
+{
+	Content = new StringContent("my aweXpect content")
+};
+
+await Expect.That(request).HasContent("*aweXpect*").AsWildcard();
+```
+
+You can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
+
+
+## `HttpResponseMessage`
+
+### Status
 
 You can verify the status code of the `HttpResponseMessage`:
 
@@ -21,8 +69,7 @@ response = await httpClient.PostAsync("https://github.com/aweXpect/aweXpect.Web"
 await Expect.That(response).HasStatusCode().ClientError().Or.HasStatusCode().ServerError().Or.HasStatusCode().Redirection();
 ```
 
-
-## Header
+### Header
 
 You can verify the headers of the `HttpResponseMessage`:
 
@@ -47,8 +94,7 @@ await Expect.That(response).HasHeader("Vary")
     .WhoseValues(values => values.Contains("Turbo-Frame"));
 ```
 
-
-## Content
+### Content
 
 You can verify, the content of the `HttpResponseMessage`:
 
@@ -58,6 +104,7 @@ HttpResponseMessage response = await httpClient.GetAsync("https://github.com/awe
 await Expect.That(response).HasContent("*aweXpect*").AsWildcard();
 ```
 
+You can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
 
 Great care was taken to provide as much information as possible, when a status verification failed.  
 The response could look similar to:
@@ -67,18 +114,19 @@ The response could look similar to:
 > but it was 404 NotFound
 > 
 > HTTP-Request:
->   HTTP/1.1 404 NotFound
+>   GET https://github.com/aweXpect/missing-repo HTTP/1.1
+> 
+> HTTP-Response:
+>   404 NotFound HTTP/1.1
 >     Server: GitHub.com
 >     Date: Fri, 29 Nov 2024 07:55:47 GMT
 >     Cache-Control: no-cache
 >     Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
 >     X-GitHub-Request-Id: DB30:24038B:287F716:29D98BD:67497384
 >   Content is binary
->   The originating request was:
->     GET https://github.com/aweXpect/missing-repo HTTP 1.1
 > ```
 
-### Problem Details
+#### Problem Details
 
 You can verify that the content contains a valid [ProblemDetails](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.problemdetails) object:
 

--- a/Source/aweXpect.Web/Helpers/ThatExtensions.cs
+++ b/Source/aweXpect.Web/Helpers/ThatExtensions.cs
@@ -12,6 +12,7 @@ internal static class ThatExtensions
 {
 	private const string HttpRequestContext = "HTTP-Request";
 	private const string HttpResponseContext = "HTTP-Response";
+
 	[ExcludeFromCodeCoverage]
 	public static IThatIs<T> ThatIs<T>(this IThat<T> subject)
 	{

--- a/Source/aweXpect.Web/Helpers/ThatExtensions.cs
+++ b/Source/aweXpect.Web/Helpers/ThatExtensions.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using aweXpect.Core;
+using aweXpect.Core.Constraints;
 
 namespace aweXpect.Helpers;
 
@@ -20,5 +24,67 @@ internal static class ThatExtensions
 		}
 
 		throw new NotSupportedException("IThat<T> must also implement IThatIs<T>");
+	}
+
+	public static async Task<ConstraintResult> AddContext(this ConstraintResult result, HttpRequestMessage request,
+		CancellationToken cancellationToken = default)
+		=> result.WithContext("HTTP-Request",
+			await HttpResponseMessageFormatter.Format(request, "  ", cancellationToken));
+
+	public static async Task<ConstraintResult> AddContext(this ConstraintResult result, HttpResponseMessage response,
+		CancellationToken cancellationToken = default)
+	{
+		if (response.RequestMessage is null)
+		{
+			return result.WithContext("HTTP-Response",
+				await HttpResponseMessageFormatter.Format(response, "  ", cancellationToken));
+		}
+
+		return result.WithContexts(
+			new ConstraintResult.Context("HTTP-Request",
+				await HttpResponseMessageFormatter.Format(response.RequestMessage, "  ", cancellationToken)),
+			new ConstraintResult.Context("HTTP-Response",
+				await HttpResponseMessageFormatter.Format(response, "  ", cancellationToken)));
+	}
+
+	public static async Task<ConstraintResult.Context[]> GetContexts(this HttpResponseMessage? response,
+		CancellationToken cancellationToken = default)
+	{
+		if (response is null)
+		{
+			return [];
+		}
+
+		if (response.RequestMessage is null)
+		{
+			return
+			[
+				new ConstraintResult.Context("HTTP-Response",
+					await HttpResponseMessageFormatter.Format(response, "  ", cancellationToken)),
+			];
+		}
+
+		return
+		[
+			new ConstraintResult.Context("HTTP-Request",
+				await HttpResponseMessageFormatter.Format(response.RequestMessage, "  ", cancellationToken)),
+			new ConstraintResult.Context("HTTP-Response",
+				await HttpResponseMessageFormatter.Format(response, "  ", cancellationToken)),
+		];
+	}
+
+	public static async Task<ConstraintResult.Context[]> GetContexts(this HttpRequestMessage? request,
+		CancellationToken cancellationToken = default)
+	{
+		if (request is null)
+		{
+			return [];
+		}
+
+		return
+		[
+			new ConstraintResult.Context("HTTP-Request",
+				await HttpResponseMessageFormatter.Format(request, "  ", cancellationToken)),
+		];
 	}
 }

--- a/Source/aweXpect.Web/Helpers/ThatExtensions.cs
+++ b/Source/aweXpect.Web/Helpers/ThatExtensions.cs
@@ -10,6 +10,8 @@ namespace aweXpect.Helpers;
 
 internal static class ThatExtensions
 {
+	private const string HttpRequestContext = "HTTP-Request";
+	private const string HttpResponseContext = "HTTP-Response";
 	[ExcludeFromCodeCoverage]
 	public static IThatIs<T> ThatIs<T>(this IThat<T> subject)
 	{
@@ -28,7 +30,7 @@ internal static class ThatExtensions
 
 	public static async Task<ConstraintResult> AddContext(this ConstraintResult result, HttpRequestMessage request,
 		CancellationToken cancellationToken = default)
-		=> result.WithContext("HTTP-Request",
+		=> result.WithContext(HttpRequestContext,
 			await HttpResponseMessageFormatter.Format(request, "  ", cancellationToken));
 
 	public static async Task<ConstraintResult> AddContext(this ConstraintResult result, HttpResponseMessage response,
@@ -36,14 +38,14 @@ internal static class ThatExtensions
 	{
 		if (response.RequestMessage is null)
 		{
-			return result.WithContext("HTTP-Response",
+			return result.WithContext(HttpResponseContext,
 				await HttpResponseMessageFormatter.Format(response, "  ", cancellationToken));
 		}
 
 		return result.WithContexts(
-			new ConstraintResult.Context("HTTP-Request",
+			new ConstraintResult.Context(HttpRequestContext,
 				await HttpResponseMessageFormatter.Format(response.RequestMessage, "  ", cancellationToken)),
-			new ConstraintResult.Context("HTTP-Response",
+			new ConstraintResult.Context(HttpResponseContext,
 				await HttpResponseMessageFormatter.Format(response, "  ", cancellationToken)));
 	}
 
@@ -59,16 +61,16 @@ internal static class ThatExtensions
 		{
 			return
 			[
-				new ConstraintResult.Context("HTTP-Response",
+				new ConstraintResult.Context(HttpResponseContext,
 					await HttpResponseMessageFormatter.Format(response, "  ", cancellationToken)),
 			];
 		}
 
 		return
 		[
-			new ConstraintResult.Context("HTTP-Request",
+			new ConstraintResult.Context(HttpRequestContext,
 				await HttpResponseMessageFormatter.Format(response.RequestMessage, "  ", cancellationToken)),
-			new ConstraintResult.Context("HTTP-Response",
+			new ConstraintResult.Context(HttpResponseContext,
 				await HttpResponseMessageFormatter.Format(response, "  ", cancellationToken)),
 		];
 	}
@@ -83,7 +85,7 @@ internal static class ThatExtensions
 
 		return
 		[
-			new ConstraintResult.Context("HTTP-Request",
+			new ConstraintResult.Context(HttpRequestContext,
 				await HttpResponseMessageFormatter.Format(request, "  ", cancellationToken)),
 		];
 	}

--- a/Source/aweXpect.Web/ThatHttpRequestMessage.HasContent.cs
+++ b/Source/aweXpect.Web/ThatHttpRequestMessage.HasContent.cs
@@ -37,7 +37,7 @@ public static partial class ThatHttpRequestMessage
 						async m => m.Content == null ? null : await m.Content.ReadAsStringAsync(),
 						" the string content"),
 					(member, stringBuilder) => stringBuilder.Append("has a string content which "))
-				.AddContexts(async httpResponse =>await httpResponse.GetContexts())
+				.AddContexts(async httpResponse => await httpResponse.GetContexts())
 				.AddExpectations(e => expectations(new ThatSubject<string?>(e)), ExpectationGrammars.Nested),
 			source);
 
@@ -70,10 +70,9 @@ public static partial class ThatHttpRequestMessage
 				return new ConstraintResult.Success<HttpRequestMessage?>(actual, ToString());
 			}
 
-			string formattedResponse =
-				await HttpResponseMessageFormatter.Format(actual, "  ", cancellationToken);
-			return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
-				options.GetExtendedFailure(it, message, expected)).WithContext("HTTP-Request", formattedResponse);
+			return await new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
+					options.GetExtendedFailure(it, message, expected))
+				.AddContext(actual, cancellationToken);
 		}
 
 		public override string ToString()

--- a/Source/aweXpect.Web/ThatHttpRequestMessage.HasContent.cs
+++ b/Source/aweXpect.Web/ThatHttpRequestMessage.HasContent.cs
@@ -10,16 +10,16 @@ using aweXpect.Results;
 
 namespace aweXpect;
 
-public static partial class ThatHttpResponseMessage
+public static partial class ThatHttpRequestMessage
 {
 	/// <summary>
 	///     Verifies that the string content is equal to <paramref name="expected" />
 	/// </summary>
-	public static StringEqualityTypeResult<HttpResponseMessage, IThat<HttpResponseMessage?>>
-		HasContent(this IThat<HttpResponseMessage?> source, string expected)
+	public static StringEqualityTypeResult<HttpRequestMessage, IThat<HttpRequestMessage?>>
+		HasContent(this IThat<HttpRequestMessage?> source, string expected)
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<HttpResponseMessage, IThat<HttpResponseMessage?>>(
+		return new StringEqualityTypeResult<HttpRequestMessage, IThat<HttpRequestMessage?>>(
 			source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new HasContentConstraint(it, expected, options)),
 			source,
@@ -29,31 +29,35 @@ public static partial class ThatHttpResponseMessage
 	/// <summary>
 	///     Verifies that the string content satisfies the <paramref name="expectations" />
 	/// </summary>
-	public static AndOrResult<HttpResponseMessage, IThat<HttpResponseMessage?>>
-		HasContent(this IThat<HttpResponseMessage?> source, Action<IThat<string?>> expectations)
-	{
-		return new AndOrResult<HttpResponseMessage, IThat<HttpResponseMessage?>>(
+	public static AndOrResult<HttpRequestMessage, IThat<HttpRequestMessage?>>
+		HasContent(this IThat<HttpRequestMessage?> source, Action<IThat<string?>> expectations)
+		=> new(
 			source.ThatIs().ExpectationBuilder
-				.ForAsyncMember(MemberAccessor<HttpResponseMessage, Task<string?>>.FromFunc(
-						async m => await m.Content.ReadAsStringAsync(),
+				.ForAsyncMember(MemberAccessor<HttpRequestMessage, Task<string?>>.FromFunc(
+						async m => m.Content == null ? null : await m.Content.ReadAsStringAsync(),
 						" the string content"),
 					(member, stringBuilder) => stringBuilder.Append("has a string content which "))
-				.AddContexts(async httpResponse => await httpResponse.GetContexts())
+				.AddContexts(async httpResponse =>await httpResponse.GetContexts())
 				.AddExpectations(e => expectations(new ThatSubject<string?>(e)), ExpectationGrammars.Nested),
 			source);
-	}
 
 	private readonly struct HasContentConstraint(string it, string expected, StringEqualityOptions options)
-		: IAsyncConstraint<HttpResponseMessage>
+		: IAsyncConstraint<HttpRequestMessage>
 	{
 		public async Task<ConstraintResult> IsMetBy(
-			HttpResponseMessage? actual,
+			HttpRequestMessage? actual,
 			CancellationToken cancellationToken)
 		{
 			if (actual == null)
 			{
-				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+				return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
 					$"{it} was <null>");
+			}
+
+			if (actual.Content is null)
+			{
+				return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
+					$"{it} had a <null> content");
 			}
 
 #if NETSTANDARD2_0
@@ -63,11 +67,13 @@ public static partial class ThatHttpResponseMessage
 #endif
 			if (options.AreConsideredEqual(message, expected))
 			{
-				return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());
+				return new ConstraintResult.Success<HttpRequestMessage?>(actual, ToString());
 			}
 
-			return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
-				options.GetExtendedFailure(it, message, expected)).AddContext(actual);
+			string formattedResponse =
+				await HttpResponseMessageFormatter.Format(actual, "  ", cancellationToken);
+			return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
+				options.GetExtendedFailure(it, message, expected)).WithContext("HTTP-Request", formattedResponse);
 		}
 
 		public override string ToString()

--- a/Source/aweXpect.Web/ThatHttpRequestMessage.HasHeader.cs
+++ b/Source/aweXpect.Web/ThatHttpRequestMessage.HasHeader.cs
@@ -11,13 +11,13 @@ using aweXpect.Web.Results;
 
 namespace aweXpect;
 
-public static partial class ThatHttpResponseMessage
+public static partial class ThatHttpRequestMessage
 {
 	/// <summary>
-	///     Verifies that the <see cref="HttpResponseMessage" /> has the <paramref name="expected" /> header.
+	///     Verifies that the <see cref="HttpRequestMessage" /> has the <paramref name="expected" /> header.
 	/// </summary>
-	public static HasHeaderValueResult<HttpResponseMessage, IThat<HttpResponseMessage?>> HasHeader(
-		this IThat<HttpResponseMessage?> source,
+	public static HasHeaderValueResult<HttpRequestMessage, IThat<HttpRequestMessage?>> HasHeader(
+		this IThat<HttpRequestMessage?> source,
 		string expected)
 		=> new(source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new HasHeaderConstraint(it, expected)),
@@ -25,36 +25,38 @@ public static partial class ThatHttpResponseMessage
 			a => a.Headers.TryGetValues(expected, out IEnumerable<string>? values) ? values.ToArray() : null);
 
 	/// <summary>
-	///     Verifies that the <see cref="HttpResponseMessage" /> does not have the <paramref name="unexpected" /> header.
+	///     Verifies that the <see cref="HttpRequestMessage" /> does not have the <paramref name="unexpected" /> header.
 	/// </summary>
-	public static AndOrResult<HttpResponseMessage, IThat<HttpResponseMessage?>> DoesNotHaveHeader(
-		this IThat<HttpResponseMessage?> source,
+	public static AndOrResult<HttpRequestMessage, IThat<HttpRequestMessage?>> DoesNotHaveHeader(
+		this IThat<HttpRequestMessage?> source,
 		string unexpected)
 		=> new(source.ThatIs().ExpectationBuilder.AddConstraint((it, grammar) =>
 				new DoesNotHaveHeaderConstraint(it, unexpected)),
 			source);
 
 	private readonly struct HasHeaderConstraint(string it, string expected)
-		: IAsyncConstraint<HttpResponseMessage>
+		: IAsyncConstraint<HttpRequestMessage>
 	{
 		public async Task<ConstraintResult> IsMetBy(
-			HttpResponseMessage? actual,
+			HttpRequestMessage? actual,
 			CancellationToken cancellationToken)
 		{
 			if (actual == null)
 			{
-				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+				return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
 					$"{it} was <null>", FurtherProcessingStrategy.IgnoreResult);
 			}
 
 			if (actual.Headers.TryGetValues(expected, out _))
 			{
-				return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());
+				return new ConstraintResult.Success<HttpRequestMessage?>(actual, ToString());
 			}
 
-			return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+			string formattedResponse =
+				await HttpResponseMessageFormatter.Format(actual, "  ", cancellationToken);
+			return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
 					$"{it} did not contain the expected header", FurtherProcessingStrategy.IgnoreResult)
-				.AddContext(actual, cancellationToken);
+				.WithContext("HTTP-Request", formattedResponse);
 		}
 
 		public override string ToString()
@@ -62,27 +64,29 @@ public static partial class ThatHttpResponseMessage
 	}
 
 	private readonly struct DoesNotHaveHeaderConstraint(string it, string unexpected)
-		: IAsyncConstraint<HttpResponseMessage>
+		: IAsyncConstraint<HttpRequestMessage>
 	{
 		public async Task<ConstraintResult> IsMetBy(
-			HttpResponseMessage? actual,
+			HttpRequestMessage? actual,
 			CancellationToken cancellationToken)
 		{
 			if (actual == null)
 			{
-				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+				return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
 					$"{it} was <null>", FurtherProcessingStrategy.IgnoreResult);
 			}
 
 			if (!actual.Headers.TryGetValues(unexpected, out IEnumerable<string>? foundHeader))
 			{
-				return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());
+				return new ConstraintResult.Success<HttpRequestMessage?>(actual, ToString());
 			}
 
-			return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+			string formattedResponse =
+				await HttpResponseMessageFormatter.Format(actual, "  ", cancellationToken);
+			return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
 					$"{it} did contain the `{unexpected}` header: {Formatter.Format(foundHeader)}",
 					FurtherProcessingStrategy.IgnoreResult)
-				.AddContext(actual);
+				.WithContext("HTTP-Request", formattedResponse);
 		}
 
 		public override string ToString()

--- a/Source/aweXpect.Web/ThatHttpRequestMessage.cs
+++ b/Source/aweXpect.Web/ThatHttpRequestMessage.cs
@@ -1,0 +1,8 @@
+﻿using System.Net.Http;
+
+namespace aweXpect;
+
+/// <summary>
+///     Expectations on <see cref="HttpRequestMessage" /> values.
+/// </summary>
+public static partial class ThatHttpRequestMessage;

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasContent.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasContent.cs
@@ -31,8 +31,7 @@ public static partial class ThatHttpResponseMessage
 	/// </summary>
 	public static AndOrResult<HttpResponseMessage, IThat<HttpResponseMessage?>>
 		HasContent(this IThat<HttpResponseMessage?> source, Action<IThat<string?>> expectations)
-	{
-		return new AndOrResult<HttpResponseMessage, IThat<HttpResponseMessage?>>(
+		=> new(
 			source.ThatIs().ExpectationBuilder
 				.ForAsyncMember(MemberAccessor<HttpResponseMessage, Task<string?>>.FromFunc(
 						async m => await m.Content.ReadAsStringAsync(),
@@ -41,7 +40,6 @@ public static partial class ThatHttpResponseMessage
 				.AddContexts(async httpResponse => await httpResponse.GetContexts())
 				.AddExpectations(e => expectations(new ThatSubject<string?>(e)), ExpectationGrammars.Nested),
 			source);
-	}
 
 	private readonly struct HasContentConstraint(string it, string expected, StringEqualityOptions options)
 		: IAsyncConstraint<HttpResponseMessage>
@@ -67,7 +65,8 @@ public static partial class ThatHttpResponseMessage
 			}
 
 			return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
-				options.GetExtendedFailure(it, message, expected)).AddContext(actual);
+					options.GetExtendedFailure(it, message, expected))
+				.AddContext(actual, cancellationToken);
 		}
 
 		public override string ToString()

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasContentType.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasContentType.cs
@@ -45,14 +45,14 @@ public static partial class ThatHttpResponseMessage
 			{
 				return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
 					$"{it} had no `Content-Type` header")
-					.AddContext(actual);
+					.AddContext(actual, cancellationToken: cancellationToken);
 			}
 
 			if (!options.AreConsideredEqual(contentType, expected))
 			{
 				return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
 						options.GetExtendedFailure(it, contentType, expected))
-					.AddContext(actual);
+					.AddContext(actual, cancellationToken: cancellationToken);
 			}
 
 			return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasContentType.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasContentType.cs
@@ -44,15 +44,15 @@ public static partial class ThatHttpResponseMessage
 			if (!actual.Content.TryGetMediaType(out string? contentType))
 			{
 				return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
-					$"{it} had no `Content-Type` header")
-					.AddContext(actual, cancellationToken: cancellationToken);
+						$"{it} had no `Content-Type` header")
+					.AddContext(actual, cancellationToken);
 			}
 
 			if (!options.AreConsideredEqual(contentType, expected))
 			{
 				return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
 						options.GetExtendedFailure(it, contentType, expected))
-					.AddContext(actual, cancellationToken: cancellationToken);
+					.AddContext(actual, cancellationToken);
 			}
 
 			return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasContentType.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasContentType.cs
@@ -43,20 +43,16 @@ public static partial class ThatHttpResponseMessage
 
 			if (!actual.Content.TryGetMediaType(out string? contentType))
 			{
-				string formattedResponse =
-					await HttpResponseMessageFormatter.Format(actual, "  ", cancellationToken);
-				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+				return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
 					$"{it} had no `Content-Type` header")
-					.WithContext("HTTP-Request", formattedResponse);
+					.AddContext(actual);
 			}
 
 			if (!options.AreConsideredEqual(contentType, expected))
 			{
-				string formattedResponse =
-					await HttpResponseMessageFormatter.Format(actual, "  ", cancellationToken);
-				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+				return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
 						options.GetExtendedFailure(it, contentType, expected))
-					.WithContext("HTTP-Request", formattedResponse);
+					.AddContext(actual);
 			}
 
 			return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasHeader.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasHeader.cs
@@ -82,7 +82,7 @@ public static partial class ThatHttpResponseMessage
 			return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
 					$"{it} did contain the `{unexpected}` header: {Formatter.Format(foundHeader)}",
 					FurtherProcessingStrategy.IgnoreResult)
-				.AddContext(actual);
+				.AddContext(actual, cancellationToken);
 		}
 
 		public override string ToString()

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasProblemDetails.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasProblemDetails.cs
@@ -117,11 +117,9 @@ public static partial class ThatHttpResponseMessage
 
 			if (failures.Any())
 			{
-				string formattedResponse =
-					await HttpResponseMessageFormatter.Format(actual, "  ", cancellationToken);
-				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+				return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
 						string.Join($"{Environment.NewLine} and ", failures))
-					.WithContext("HTTP-Request", formattedResponse);
+					.AddContext(actual);
 			}
 
 			return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasProblemDetails.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasProblemDetails.cs
@@ -119,7 +119,7 @@ public static partial class ThatHttpResponseMessage
 			{
 				return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
 						string.Join($"{Environment.NewLine} and ", failures))
-					.AddContext(actual);
+					.AddContext(actual, cancellationToken);
 			}
 
 			return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());

--- a/Source/aweXpect.Web/Web/Results/StatusCodeResult.cs
+++ b/Source/aweXpect.Web/Web/Results/StatusCodeResult.cs
@@ -131,10 +131,9 @@ public class StatusCodeResult(
 				return new ConstraintResult.Success<HttpResponseMessage>(actual, ToString());
 			}
 
-			string formattedResponse =
-				await HttpResponseMessageFormatter.Format(actual, "  ", cancellationToken);
-			return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
-				$"{it} had status code {Formatter.Format(value)}").WithContext("HTTP-Request", formattedResponse);
+			return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
+				$"{it} had status code {Formatter.Format(value)}")
+				.AddContext(actual, cancellationToken: cancellationToken);
 		}
 
 		public override string ToString()

--- a/Source/aweXpect.Web/Web/Results/StatusCodeResult.cs
+++ b/Source/aweXpect.Web/Web/Results/StatusCodeResult.cs
@@ -132,8 +132,8 @@ public class StatusCodeResult(
 			}
 
 			return await new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
-				$"{it} had status code {Formatter.Format(value)}")
-				.AddContext(actual, cancellationToken: cancellationToken);
+					$"{it} had status code {Formatter.Format(value)}")
+				.AddContext(actual, cancellationToken);
 		}
 
 		public override string ToString()

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -2,6 +2,13 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace aweXpect
 {
+    public static class ThatHttpRequestMessage
+    {
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> DoesNotHaveHeader(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string unexpected) { }
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Action<aweXpect.Core.IThat<string?>> expectations) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
+        public static aweXpect.Web.Results.HasHeaderValueResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasHeader(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
+    }
     public static class ThatHttpResponseMessage
     {
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> DoesNotHaveHeader(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string unexpected) { }

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -2,6 +2,13 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace aweXpect
 {
+    public static class ThatHttpRequestMessage
+    {
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> DoesNotHaveHeader(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string unexpected) { }
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Action<aweXpect.Core.IThat<string?>> expectations) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
+        public static aweXpect.Web.Results.HasHeaderValueResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasHeader(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
+    }
     public static class ThatHttpResponseMessage
     {
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> DoesNotHaveHeader(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, string unexpected) { }

--- a/Tests/aweXpect.Web.Samples.Tests/CommentsTests.cs
+++ b/Tests/aweXpect.Web.Samples.Tests/CommentsTests.cs
@@ -55,10 +55,10 @@ public class CommentsTests(WebApplicationFactory<Program> factory) : IClassFixtu
 			             Expected that response
 			             has status code 404 NotFound,
 			             but it had status code 200 OK
-			             
+
 			             HTTP-Request:
 			               GET http://localhost/comments HTTP/1.1
-			             
+
 			             HTTP-Response:
 			               200 OK HTTP/1.1
 			                 Content-Type: application/json; charset=utf-8

--- a/Tests/aweXpect.Web.Samples.Tests/CommentsTests.cs
+++ b/Tests/aweXpect.Web.Samples.Tests/CommentsTests.cs
@@ -55,9 +55,12 @@ public class CommentsTests(WebApplicationFactory<Program> factory) : IClassFixtu
 			             Expected that response
 			             has status code 404 NotFound,
 			             but it had status code 200 OK
-
+			             
 			             HTTP-Request:
-			               HTTP/1.1 200 OK
+			               GET http://localhost/comments HTTP/1.1
+			             
+			             HTTP-Response:
+			               200 OK HTTP/1.1
 			                 Content-Type: application/json; charset=utf-8
 			               [
 			                 {
@@ -71,8 +74,6 @@ public class CommentsTests(WebApplicationFactory<Program> factory) : IClassFixtu
 			                   "body": "Another comment (my second)"
 			                 }
 			               ]
-			               The originating request was:
-			                 GET http://localhost/comments HTTP 1.1
 			             """);
 	}
 }

--- a/Tests/aweXpect.Web.Tests/TestHelpers/HttpRequestBuilder.cs
+++ b/Tests/aweXpect.Web.Tests/TestHelpers/HttpRequestBuilder.cs
@@ -63,7 +63,7 @@ internal class HttpRequestBuilder
 		httpRequestMessage.Method = _method;
 		httpRequestMessage.RequestUri = new Uri(_uri);
 		httpRequestMessage.Content = _content;
-		if (!string.IsNullOrEmpty(_contentType))
+		if (!string.IsNullOrEmpty(_contentType) && httpRequestMessage.Content != null)
 		{
 			httpRequestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(_contentType);
 		}

--- a/Tests/aweXpect.Web.Tests/TestHelpers/HttpRequestBuilder.cs
+++ b/Tests/aweXpect.Web.Tests/TestHelpers/HttpRequestBuilder.cs
@@ -8,10 +8,10 @@ internal class HttpRequestBuilder
 {
 	private readonly Dictionary<string, string> _headers = new();
 	private readonly Dictionary<string, string[]> _multiHeaders = new();
-	private HttpMethod _method = HttpMethod.Head;
-	private string _uri = "https://aweXpect.com";
 	private HttpContent? _content;
 	private string? _contentType;
+	private HttpMethod _method = HttpMethod.Head;
+	private string _uri = "https://aweXpect.com";
 
 	/// <summary>
 	///     Implicitly converts the <paramref name="builder" /> to a <see cref="HttpResponseMessage" />.

--- a/Tests/aweXpect.Web.Tests/TestHelpers/HttpRequestBuilder.cs
+++ b/Tests/aweXpect.Web.Tests/TestHelpers/HttpRequestBuilder.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace aweXpect.Web.Tests.TestHelpers;
+
+internal class HttpRequestBuilder
+{
+	private readonly Dictionary<string, string> _headers = new();
+	private readonly Dictionary<string, string[]> _multiHeaders = new();
+	private HttpMethod _method = HttpMethod.Head;
+	private string _uri = "https://aweXpect.com";
+	private HttpContent? _content;
+	private string? _contentType;
+
+	/// <summary>
+	///     Implicitly converts the <paramref name="builder" /> to a <see cref="HttpResponseMessage" />.
+	/// </summary>
+	public static implicit operator HttpRequestMessage(HttpRequestBuilder builder)
+	{
+		return builder.Build();
+	}
+
+	public HttpRequestBuilder WithMethod(HttpMethod method)
+	{
+		_method = method;
+		return this;
+	}
+
+	public HttpRequestBuilder WithUri(string uri)
+	{
+		_uri = uri;
+		return this;
+	}
+
+	public HttpRequestBuilder WithContent(string content)
+	{
+		_content = new StringContent(content);
+		return this;
+	}
+
+	public HttpRequestBuilder WithHeader(string name, string value)
+	{
+		_headers.Add(name, value);
+		return this;
+	}
+
+	public HttpRequestBuilder WithHeaders(string name, params string[] values)
+	{
+		_multiHeaders.Add(name, values);
+		return this;
+	}
+
+	public HttpRequestBuilder WithContentType(string mediaType)
+	{
+		_contentType = mediaType;
+		return this;
+	}
+
+	private HttpRequestMessage Build()
+	{
+		HttpRequestMessage httpRequestMessage = new();
+		httpRequestMessage.Method = _method;
+		httpRequestMessage.RequestUri = new Uri(_uri);
+		httpRequestMessage.Content = _content;
+		if (!string.IsNullOrEmpty(_contentType))
+		{
+			httpRequestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(_contentType);
+		}
+
+		foreach (KeyValuePair<string, string> header in _headers)
+		{
+			httpRequestMessage.Headers.Add(header.Key, header.Value);
+		}
+
+		foreach (KeyValuePair<string, string[]> header in _multiHeaders)
+		{
+			httpRequestMessage.Headers.Add(header.Key, header.Value);
+		}
+
+		return httpRequestMessage;
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.DoesNotHaveHeader.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.DoesNotHaveHeader.Tests.cs
@@ -2,7 +2,7 @@
 
 namespace aweXpect.Tests;
 
-public sealed partial class ThatHttpResponseMessage
+public sealed partial class ThatHttpRequestMessage
 {
 	public sealed class DoesNotHaveHeader
 	{
@@ -12,7 +12,7 @@ public sealed partial class ThatHttpResponseMessage
 			public async Task WhenHeaderDoesNotExist_ShouldSucceed()
 			{
 				string name = "x-my-header";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithContent("some content");
 
 				async Task Act()
@@ -25,7 +25,7 @@ public sealed partial class ThatHttpResponseMessage
 			public async Task WhenHeaderExists_ShouldFail()
 			{
 				string name = "x-my-header";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithHeader(name, "some header")
 					.WithContent("some content");
 
@@ -38,8 +38,8 @@ public sealed partial class ThatHttpResponseMessage
 					             does not have a `x-my-header` header,
 					             but it did contain the `x-my-header` header: ["some header"]
 
-					             HTTP-Response:
-					               200 OK HTTP/1.1
+					             HTTP-Request:
+					               HEAD https://awexpect.com/ HTTP/1.1
 					                 x-my-header: some header
 					                 Content-Type: text/plain; charset=utf-8
 					               some content
@@ -49,7 +49,7 @@ public sealed partial class ThatHttpResponseMessage
 			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
-				HttpResponseMessage? subject = null;
+				HttpRequestMessage? subject = null;
 
 				async Task Act()
 					=> await That(subject).DoesNotHaveHeader("x-my-header");

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasContent.ExpectationsTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasContent.ExpectationsTests.cs
@@ -2,34 +2,34 @@
 
 namespace aweXpect.Tests;
 
-public sealed partial class ThatHttpResponseMessage
+public sealed partial class ThatHttpRequestMessage
 {
 	public sealed partial class HasContent
 	{
-		public sealed class Tests
+		public sealed class ExpectationsTests
 		{
 			[Fact]
 			public async Task WhenContentDiffersFromExpected_ShouldFail()
 			{
 				string expected = "other content";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithContent("some content");
 
 				async Task Act()
-					=> await That(subject).HasContent(expected);
+					=> await That(subject).HasContent(which => which.IsEqualTo(expected));
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a string content equal to "other content",
-					             but it was "some content" which differs at index 0:
+					             has a string content which is equal to "other content",
+					             but the string content was "some content" which differs at index 0:
 					                ↓ (actual)
 					               "some content"
 					               "other content"
 					                ↑ (expected)
 
-					             HTTP-Response:
-					               200 OK HTTP/1.1
+					             HTTP-Request:
+					               HEAD https://awexpect.com/ HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					                 Content-Length: 12
 					               some content
@@ -40,11 +40,11 @@ public sealed partial class ThatHttpResponseMessage
 			public async Task WhenContentEqualsExpected_ShouldSucceed()
 			{
 				string expected = "some content";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithContent(expected);
 
 				async Task Act()
-					=> await That(subject).HasContent(expected);
+					=> await That(subject).HasContent(which => which.IsEqualTo(expected));
 
 				await That(Act).DoesNotThrow();
 			}
@@ -52,15 +52,15 @@ public sealed partial class ThatHttpResponseMessage
 			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
-				HttpResponseMessage? subject = null;
+				HttpRequestMessage? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasContent("some content");
+					=> await That(subject).HasContent(which => which.IsEmpty());
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a string content equal to "some content",
+					             has a string content which is empty,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasContent.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasContent.Tests.cs
@@ -2,7 +2,7 @@
 
 namespace aweXpect.Tests;
 
-public sealed partial class ThatHttpResponseMessage
+public sealed partial class ThatHttpRequestMessage
 {
 	public sealed partial class HasContent
 	{
@@ -12,7 +12,7 @@ public sealed partial class ThatHttpResponseMessage
 			public async Task WhenContentDiffersFromExpected_ShouldFail()
 			{
 				string expected = "other content";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithContent("some content");
 
 				async Task Act()
@@ -28,8 +28,8 @@ public sealed partial class ThatHttpResponseMessage
 					               "other content"
 					                ↑ (expected)
 
-					             HTTP-Response:
-					               200 OK HTTP/1.1
+					             HTTP-Request:
+					               HEAD https://awexpect.com/ HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					                 Content-Length: 12
 					               some content
@@ -40,7 +40,7 @@ public sealed partial class ThatHttpResponseMessage
 			public async Task WhenContentEqualsExpected_ShouldSucceed()
 			{
 				string expected = "some content";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithContent(expected);
 
 				async Task Act()
@@ -52,7 +52,7 @@ public sealed partial class ThatHttpResponseMessage
 			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
-				HttpResponseMessage? subject = null;
+				HttpRequestMessage? subject = null;
 
 				async Task Act()
 					=> await That(subject).HasContent("some content");

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Net.Http;
+﻿using System.Net.Http;
 
 namespace aweXpect.Tests;
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.Tests.cs
@@ -3,7 +3,7 @@ using System.Net.Http;
 
 namespace aweXpect.Tests;
 
-public sealed partial class ThatHttpResponseMessage
+public sealed partial class ThatHttpRequestMessage
 {
 	public sealed partial class HasHeader
 	{
@@ -13,7 +13,7 @@ public sealed partial class ThatHttpResponseMessage
 			public async Task WhenHeaderDoesNotExist_ShouldFail()
 			{
 				string name = "x-my-header";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithContent("some content");
 
 				async Task Act()
@@ -25,8 +25,8 @@ public sealed partial class ThatHttpResponseMessage
 					             has a `x-my-header` header,
 					             but it did not contain the expected header
 
-					             HTTP-Response:
-					               200 OK HTTP/1.1
+					             HTTP-Request:
+					               HEAD https://awexpect.com/ HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					               some content
 					             """);
@@ -36,7 +36,7 @@ public sealed partial class ThatHttpResponseMessage
 			public async Task WhenHeaderExists_ShouldSucceed()
 			{
 				string name = "x-my-header";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithHeader(name, "some header");
 
 				async Task Act()
@@ -48,7 +48,7 @@ public sealed partial class ThatHttpResponseMessage
 			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
-				HttpResponseMessage? subject = null;
+				HttpRequestMessage? subject = null;
 
 				async Task Act()
 					=> await That(subject).HasHeader("x-my-header");

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.WhoseValueTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.WhoseValueTests.cs
@@ -2,7 +2,7 @@
 
 namespace aweXpect.Tests;
 
-public sealed partial class ThatHttpResponseMessage
+public sealed partial class ThatHttpRequestMessage
 {
 	public sealed partial class HasHeader
 	{
@@ -14,7 +14,7 @@ public sealed partial class ThatHttpResponseMessage
 				string name = "x-my-header";
 				string value = "some header";
 				string otherKey = "x-some-other-key";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithHeader(name, value);
 
 				async Task Act()
@@ -26,10 +26,9 @@ public sealed partial class ThatHttpResponseMessage
 					             has a `x-some-other-key` header whose value is equal to "some header",
 					             but it did not contain the expected header
 
-					             HTTP-Response:
-					               200 OK HTTP/1.1
+					             HTTP-Request:
+					               HEAD https://awexpect.com/ HTTP/1.1
 					                 x-my-header: some header
-					                 Content-Type: text/plain; charset=utf-8
 					             """);
 			}
 
@@ -39,7 +38,7 @@ public sealed partial class ThatHttpResponseMessage
 				string name = "x-my-header";
 				string value = "some header";
 				string expectedValue = "some other header";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithHeader(name, value);
 
 				async Task Act()
@@ -62,7 +61,7 @@ public sealed partial class ThatHttpResponseMessage
 			{
 				string name = "x-my-header";
 				string value = "some header";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithHeader(name, value);
 
 				async Task Act()
@@ -74,7 +73,7 @@ public sealed partial class ThatHttpResponseMessage
 			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
-				HttpResponseMessage? subject = null;
+				HttpRequestMessage? subject = null;
 
 				async Task Act()
 					=> await That(subject).HasHeader("x-my-key").WhoseValue(v => v.IsEmpty());

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.WhoseValuesTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.WhoseValuesTests.cs
@@ -32,10 +32,6 @@ public sealed partial class ThatHttpRequestMessage
 					                 x-my-header: bar
 					                 x-my-header: baz
 					             """);
-				new HttpRequestMessage(HttpMethod.Post, "https://github.com/aweXpect/aweXpect.Web")
-				{
-					Content = new StringContent("my content")
-				};
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.WithValueTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.WithValueTests.cs
@@ -2,11 +2,11 @@
 
 namespace aweXpect.Tests;
 
-public sealed partial class ThatHttpResponseMessage
+public sealed partial class ThatHttpRequestMessage
 {
 	public sealed partial class HasHeader
 	{
-		public sealed class WhoseValueTests
+		public sealed class WithValueTests
 		{
 			[Fact]
 			public async Task WhenHeaderDoesNotExist_ShouldFail()
@@ -14,11 +14,11 @@ public sealed partial class ThatHttpResponseMessage
 				string name = "x-my-header";
 				string value = "some header";
 				string otherKey = "x-some-other-key";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithHeader(name, value);
 
 				async Task Act()
-					=> await That(subject).HasHeader(otherKey).WhoseValue(v => v.IsEqualTo(value));
+					=> await That(subject).HasHeader(otherKey).WithValue(value);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -26,10 +26,9 @@ public sealed partial class ThatHttpResponseMessage
 					             has a `x-some-other-key` header whose value is equal to "some header",
 					             but it did not contain the expected header
 
-					             HTTP-Response:
-					               200 OK HTTP/1.1
+					             HTTP-Request:
+					               HEAD https://awexpect.com/ HTTP/1.1
 					                 x-my-header: some header
-					                 Content-Type: text/plain; charset=utf-8
 					             """);
 			}
 
@@ -39,11 +38,11 @@ public sealed partial class ThatHttpResponseMessage
 				string name = "x-my-header";
 				string value = "some header";
 				string expectedValue = "some other header";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithHeader(name, value);
 
 				async Task Act()
-					=> await That(subject).HasHeader(name).WhoseValue(v => v.IsEqualTo(expectedValue));
+					=> await That(subject).HasHeader(name).WithValue(expectedValue);
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -62,11 +61,11 @@ public sealed partial class ThatHttpResponseMessage
 			{
 				string name = "x-my-header";
 				string value = "some header";
-				HttpResponseMessage subject = ResponseBuilder
+				HttpRequestMessage subject = RequestBuilder
 					.WithHeader(name, value);
 
 				async Task Act()
-					=> await That(subject).HasHeader(name).WhoseValue(v => v.IsEqualTo(value));
+					=> await That(subject).HasHeader(name).WithValue(value);
 
 				await That(Act).DoesNotThrow();
 			}
@@ -74,15 +73,15 @@ public sealed partial class ThatHttpResponseMessage
 			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
-				HttpResponseMessage? subject = null;
+				HttpRequestMessage? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasHeader("x-my-key").WhoseValue(v => v.IsEmpty());
+					=> await That(subject).HasHeader("x-my-key").WithValue("foo");
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a `x-my-key` header whose value is empty,
+					             has a `x-my-key` header whose value is equal to "foo",
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+using aweXpect.Web.Tests.TestHelpers;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatHttpRequestMessage
+{
+	private static HttpRequestBuilder RequestBuilder => new();
+}

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using aweXpect.Web.Tests.TestHelpers;
+﻿using aweXpect.Web.Tests.TestHelpers;
 
 namespace aweXpect.Tests;
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContent.ExpectationsTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContent.ExpectationsTests.cs
@@ -28,12 +28,11 @@ public sealed partial class ThatHttpResponseMessage
 					               "other content"
 					                ↑ (expected)
 
-					             HTTP-Request:
-					               HTTP/1.1 200 OK
+					             HTTP-Response:
+					               200 OK HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					                 Content-Length: 12
 					               some content
-					               The originating request was <null>
 					             """);
 			}
 
@@ -63,9 +62,6 @@ public sealed partial class ThatHttpResponseMessage
 					             Expected that subject
 					             has a string content which is empty,
 					             but it was <null>
-					             
-					             HTTP-Request:
-					             <null>
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContentType.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContentType.Tests.cs
@@ -43,11 +43,10 @@ public sealed partial class ThatHttpResponseMessage
 					               "text/content-type"
 					                     ↑ (expected)
 
-					             HTTP-Request:
-					               HTTP/1.1 200 OK
+					             HTTP-Response:
+					               200 OK HTTP/1.1
 					                 Content-Type: text/other-content-type
 					               some content
-					               The originating request was <null>
 					             """);
 			}
 
@@ -67,10 +66,9 @@ public sealed partial class ThatHttpResponseMessage
 					             has a `Content-Type` header equal to "text/content-type",
 					             but it had no `Content-Type` header
 
-					             HTTP-Request:
-					               HTTP/1.1 200 OK
+					             HTTP-Response:
+					               200 OK HTTP/1.1
 					               *Content with length 2*
-					               The originating request was <null>
 					             """);
 			}
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Net.Http;
+﻿using System.Net.Http;
 
 namespace aweXpect.Tests;
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WhoseValuesTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WhoseValuesTests.cs
@@ -26,14 +26,12 @@ public sealed partial class ThatHttpResponseMessage
 					             has a `x-some-other-key` header whose values has exactly 3 items,
 					             but it did not contain the expected header
 
-					             HTTP-Request:
-					               HTTP/1.1 200 OK
+					             HTTP-Response:
+					               200 OK HTTP/1.1
 					                 x-my-header: foo
 					                 x-my-header: bar
 					                 x-my-header: baz
 					                 Content-Type: text/plain; charset=utf-8
-					               
-					               The originating request was <null>
 					             """);
 			}
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WithValueTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WithValueTests.cs
@@ -26,12 +26,10 @@ public sealed partial class ThatHttpResponseMessage
 					             has a `x-some-other-key` header whose value is equal to "some header",
 					             but it did not contain the expected header
 
-					             HTTP-Request:
-					               HTTP/1.1 200 OK
+					             HTTP-Response:
+					               200 OK HTTP/1.1
 					                 x-my-header: some header
 					                 Content-Type: text/plain; charset=utf-8
-					               
-					               The originating request was <null>
 					             """);
 			}
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.Tests.cs
@@ -40,8 +40,8 @@ public sealed partial class ThatHttpResponseMessage
 					               "could-be-SOME-guid "
 					                         ↑ (expected)
 
-					             HTTP-Request:
-					               HTTP/1.1 200 OK
+					             HTTP-Response:
+					               200 OK HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					                 Content-Length: *
 					               {
@@ -50,7 +50,6 @@ public sealed partial class ThatHttpResponseMessage
 					                 "status": 404,
 					                 "instance": "could-be-some-guid"
 					               }
-					               The originating request was <null>
 					             """).AsWildcard();
 			}
 
@@ -73,14 +72,13 @@ public sealed partial class ThatHttpResponseMessage
 					             has a ProblemDetails content with type "foo",
 					             but it did not match the expected format because no 'type' property existed
 
-					             HTTP-Request:
-					               HTTP/1.1 200 OK
+					             HTTP-Response:
+					               200 OK HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					                 Content-Length: *
 					               {
 					                 "no-type": "foo"
 					               }
-					               The originating request was <null>
 					             """).AsWildcard();
 			}
 
@@ -141,14 +139,13 @@ public sealed partial class ThatHttpResponseMessage
 					                 "{{expectedType}}"
 					                  ↑ (expected)
 
-					               HTTP-Request:
-					                 HTTP/1.1 200 OK
+					               HTTP-Response:
+					                 200 OK HTTP/1.1
 					                   Content-Type: text/plain; charset=utf-8
 					                   Content-Length: *
 					                 {
 					                   "type": "{{actualType}}"
 					                 }
-					                 The originating request was <null>
 					               """).AsWildcard();
 			}
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithDetailTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithDetailTests.cs
@@ -51,15 +51,14 @@ public sealed partial class ThatHttpResponseMessage
 					                 "{{expectedDetail}}"
 					                  ↑ (expected)
 
-					               HTTP-Request:
-					                 HTTP/1.1 200 OK
+					               HTTP-Response:
+					                 200 OK HTTP/1.1
 					                   Content-Type: text/plain; charset=utf-8
 					                   Content-Length: *
 					                 {
 					                   "type": "my-type",
 					                   "detail": "{{actualDetail}}"
 					                 }
-					                 The originating request was <null>
 					               """).AsWildcard();
 			}
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithInstanceTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithInstanceTests.cs
@@ -51,15 +51,14 @@ public sealed partial class ThatHttpResponseMessage
 					                 "{{expectedInstance}}"
 					                  ↑ (expected)
 
-					               HTTP-Request:
-					                 HTTP/1.1 200 OK
+					               HTTP-Response:
+					                 200 OK HTTP/1.1
 					                   Content-Type: text/plain; charset=utf-8
 					                   Content-Length: *
 					                 {
 					                   "type": "my-type",
 					                   "instance": "{{actualInstance}}"
 					                 }
-					                 The originating request was <null>
 					               """).AsWildcard();
 			}
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithStatusTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithStatusTests.cs
@@ -30,15 +30,14 @@ public sealed partial class ThatHttpResponseMessage
 					               has a ProblemDetails content with any type and status {{expectedStatus}},
 					               but it had status {{actualStatus}}
 
-					               HTTP-Request:
-					                 HTTP/1.1 200 OK
+					               HTTP-Response:
+					                 200 OK HTTP/1.1
 					                   Content-Type: text/plain; charset=utf-8
 					                   Content-Length: *
 					                 {
 					                   "type": "my-type",
 					                   "status": {{actualStatus}}
 					                 }
-					                 The originating request was <null>
 					               """).AsWildcard();
 			}
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithTitleTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithTitleTests.cs
@@ -51,15 +51,14 @@ public sealed partial class ThatHttpResponseMessage
 					                 "{{expectedTitle}}"
 					                  ↑ (expected)
 
-					               HTTP-Request:
-					                 HTTP/1.1 200 OK
+					               HTTP-Response:
+					                 200 OK HTTP/1.1
 					                   Content-Type: text/plain; charset=utf-8
 					                   Content-Length: *
 					                 {
 					                   "type": "my-type",
 					                   "title": "{{actualTitle}}"
 					                 }
-					                 The originating request was <null>
 					               """).AsWildcard();
 			}
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.EqualToTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.EqualToTests.cs
@@ -15,7 +15,7 @@ public sealed partial class ThatHttpResponseMessage
 				HttpResponseMessage subject = ResponseBuilder
 					.WithStatusCode(HttpStatusCode.BadRequest)
 					.WithContent("some content")
-					.WithRequest(HttpMethod.Get, "https://example.com")
+					.WithRequest(HttpMethod.Get, "https://awexpect.com")
 					.WithRequestContent("request content");
 
 				async Task Act()
@@ -26,15 +26,16 @@ public sealed partial class ThatHttpResponseMessage
 					             Expected that subject
 					             has status code 200 OK,
 					             but it had status code 400 BadRequest
-
+					             
 					             HTTP-Request:
-					               HTTP/1.1 400 BadRequest
+					               GET https://awexpect.com/ HTTP/1.1
+					                 Content-Type: text/plain; charset=utf-8
+					               request content
+					             
+					             HTTP-Response:
+					               400 BadRequest HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					               some content
-					               The originating request was:
-					                 GET https://example.com/ HTTP 1.1
-					                   Content-Type: text/plain; charset=utf-8
-					                 request content
 					             """);
 			}
 
@@ -54,11 +55,10 @@ public sealed partial class ThatHttpResponseMessage
 					             has status code 200 OK,
 					             but it had status code 400 BadRequest
 
-					             HTTP-Request:
-					               HTTP/1.1 400 BadRequest
+					             HTTP-Response:
+					               400 BadRequest HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					               some content
-					               The originating request was <null>
 					             """);
 			}
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.EqualToTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.EqualToTests.cs
@@ -26,12 +26,12 @@ public sealed partial class ThatHttpResponseMessage
 					             Expected that subject
 					             has status code 200 OK,
 					             but it had status code 400 BadRequest
-					             
+
 					             HTTP-Request:
 					               GET https://awexpect.com/ HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					               request content
-					             
+
 					             HTTP-Response:
 					               400 BadRequest HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.Tests.cs
@@ -15,7 +15,7 @@ public sealed partial class ThatHttpResponseMessage
 				HttpResponseMessage subject = ResponseBuilder
 					.WithStatusCode(HttpStatusCode.BadRequest)
 					.WithContent("some content")
-					.WithRequest(HttpMethod.Get, "https://example.com")
+					.WithRequest(HttpMethod.Get, "https://awexpect.com")
 					.WithRequestContent("request content");
 
 				async Task Act()
@@ -26,15 +26,16 @@ public sealed partial class ThatHttpResponseMessage
 					             Expected that subject
 					             has status code 200 OK,
 					             but it had status code 400 BadRequest
-
+					             
 					             HTTP-Request:
-					               HTTP/1.1 400 BadRequest
+					               GET https://awexpect.com/ HTTP/1.1
+					                 Content-Type: text/plain; charset=utf-8
+					               request content
+					             
+					             HTTP-Response:
+					               400 BadRequest HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					               some content
-					               The originating request was:
-					                 GET https://example.com/ HTTP 1.1
-					                   Content-Type: text/plain; charset=utf-8
-					                 request content
 					             """);
 			}
 
@@ -54,11 +55,10 @@ public sealed partial class ThatHttpResponseMessage
 					             has status code 200 OK,
 					             but it had status code 400 BadRequest
 
-					             HTTP-Request:
-					               HTTP/1.1 400 BadRequest
+					             HTTP-Response:
+					               400 BadRequest HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					               some content
-					               The originating request was <null>
 					             """);
 			}
 

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.Tests.cs
@@ -26,12 +26,12 @@ public sealed partial class ThatHttpResponseMessage
 					             Expected that subject
 					             has status code 200 OK,
 					             but it had status code 400 BadRequest
-					             
+
 					             HTTP-Request:
 					               GET https://awexpect.com/ HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8
 					               request content
-					             
+
 					             HTTP-Response:
 					               400 BadRequest HTTP/1.1
 					                 Content-Type: text/plain; charset=utf-8

--- a/Tests/aweXpect.Web.Tests/Web/ContentProcessor.BinaryContentProcessorTests.cs
+++ b/Tests/aweXpect.Web.Tests/Web/ContentProcessor.BinaryContentProcessorTests.cs
@@ -22,11 +22,10 @@ public sealed partial class ContentProcessor
 				             has status code 202 Accepted,
 				             but it had status code 200 OK
 
-				             HTTP-Request:
-				               HTTP/1.1 200 OK
+				             HTTP-Response:
+				               200 OK HTTP/1.1
 				                 Content-Type: text/css
 				               foo
-				               The originating request was <null>
 				             """);
 		}
 
@@ -55,11 +54,10 @@ public sealed partial class ContentProcessor
 				               has status code 202 Accepted,
 				               but it had status code 200 OK
 
-				               HTTP-Request:
-				                 HTTP/1.1 200 OK
+				               HTTP-Response:
+				                 200 OK HTTP/1.1
 				                   Content-Type: {{contentType}}
 				                 *Content is binary ({{contentType}}) with length {{bytes.Length}}*
-				                 The originating request was <null>
 				               """);
 		}
 	}

--- a/Tests/aweXpect.Web.Tests/Web/ContentProcessor.JsonContentProcessorTests.cs
+++ b/Tests/aweXpect.Web.Tests/Web/ContentProcessor.JsonContentProcessorTests.cs
@@ -27,12 +27,11 @@ public sealed partial class ContentProcessor
 				               has status code 202 Accepted,
 				               but it had status code 200 OK
 
-				               HTTP-Request:
-				                 HTTP/1.1 200 OK
+				               HTTP-Response:
+				                 200 OK HTTP/1.1
 				                   Content-Type: {{contentType}}
 				                 {"my-content":1
 				                 *** JSON parse error: '1' is an invalid end of a number. Expected a delimiter. LineNumber: 0 | BytePositionInLine: 15. ***
-				                 The originating request was <null>
 				               """);
 		}
 
@@ -55,13 +54,12 @@ public sealed partial class ContentProcessor
 				               has status code 202 Accepted,
 				               but it had status code 200 OK
 
-				               HTTP-Request:
-				                 HTTP/1.1 200 OK
+				               HTTP-Response:
+				                 200 OK HTTP/1.1
 				                   Content-Type: {{contentType}}
 				                 {
 				                   "my-content": 1
 				                 }
-				                 The originating request was <null>
 				               """);
 		}
 	}

--- a/Tests/aweXpect.Web.Tests/Web/ContentProcessor.StringContentProcessorTests.cs
+++ b/Tests/aweXpect.Web.Tests/Web/ContentProcessor.StringContentProcessorTests.cs
@@ -32,11 +32,10 @@ public sealed partial class ContentProcessor
 					               has status code 202 Accepted,
 					               but it had status code 200 OK
 
-					               HTTP-Request:
-					                 HTTP/1.1 200 OK
+					               HTTP-Response:
+					                 200 OK HTTP/1.1
 					                   Content-Type: {{contentType}}
 					                 {"my-content":1}
-					                 The originating request was <null>
 					               """);
 			}
 		}
@@ -61,13 +60,12 @@ public sealed partial class ContentProcessor
 				             has status code 202 Accepted,
 				             but it had status code 200 OK
 
-				             HTTP-Request:
-				               HTTP/1.1 200 OK
+				             HTTP-Response:
+				               200 OK HTTP/1.1
 				                 Content-Type: text/css
 				               body {
 				                   background-color: powderblue;
 				               }
-				               The originating request was <null>
 				             """);
 		}
 
@@ -93,11 +91,10 @@ public sealed partial class ContentProcessor
 				               has status code 202 Accepted,
 				               but it had status code 200 OK
 
-				               HTTP-Request:
-				                 HTTP/1.1 200 OK
+				               HTTP-Response:
+				                 200 OK HTTP/1.1
 				                   Content-Type: {{contentType}}
 				                 {"my-content":1}
-				                 The originating request was <null>
 				               """);
 		}
 	}

--- a/Tests/aweXpect.Web.Tests/Web/ContentProcessor.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/Web/ContentProcessor.Tests.cs
@@ -26,11 +26,10 @@ public sealed partial class ContentProcessor
 				             has status code 202 Accepted,
 				             but it had status code 200 OK
 
-				             HTTP-Request:
-				               HTTP/1.1 200 OK
+				             HTTP-Response:
+				               200 OK HTTP/1.1
 				                 Content-Type: application/my-type
 				               *Content (application/my-type) with length 0*
-				               The originating request was <null>
 				             """);
 		}
 
@@ -49,11 +48,10 @@ public sealed partial class ContentProcessor
 				             has status code 202 Accepted,
 				             but it had status code 200 OK
 
-				             HTTP-Request:
-				               HTTP/1.1 200 OK
+				             HTTP-Response:
+				               200 OK HTTP/1.1
 				                 Content-Type: application/my-type
 				               *Content (application/my-type) with length 0*
-				               The originating request was <null>
 				             """);
 		}
 	}


### PR DESCRIPTION
### Header

You can verify the headers of the `HttpRequestMessage`:

```csharp
HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
// Add headers

await Expect.That(request).HasHeader("X-GitHub-Request-Id");
await Expect.That(request).HasHeader("Cache-Control")
    .WithValue("must-revalidate, max-age=0, private");

await Expect.That(request).DoesNotHaveHeader("X-My-Header");
```

You can also add additional expectations on the header value(s):

```csharp
HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
// Add headers

await Expect.That(request).HasHeader("X-GitHub-Request-Id")
    .WhoseValue(value => value.IsNotEmpty());
await Expect.That(request).HasHeader("Vary")
    .WhoseValues(values => values.Contains("Turbo-Frame"));
```

### Content

You can verify, the content of the `HttpRequestMessage`:

```csharp
var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/aweXpect/aweXpect.Web")
{
	Content = new StringContent("my aweXpect content")
};

await Expect.That(request).HasContent("*aweXpect*").AsWildcard();
```

You can use the same configuration options as when [comparing strings](https://awexpect.com/docs/expectations/string#equality).

*See #32*