### PR TITLE
feat: add `HasMethod` and `HasRequestUri`

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -25,9 +25,6 @@ await Expect.That(request).HasRequestUri("https://github.com/aweXpect/aweXpect.W
 await Expect.That(request).HasRequestUri(new Uri("https://github.com/aweXpect/aweXpect.Web"));
 ```
 
-You can use the same configuration options as
-when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
-
 ### Header
 
 You can verify the headers of the `HttpRequestMessage`:

--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -4,6 +4,30 @@ Expectations for `HttpClient`.
 
 ## `HttpRequestMessage`
 
+### Method
+
+You can verify, the method of the `HttpRequestMessage`:
+
+```csharp
+var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+
+await Expect.That(request).HasMethod(HttpMethod.Get);
+```
+
+### Request URI
+
+You can verify, the request URI of the `HttpRequestMessage`:
+
+```csharp
+var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+
+await Expect.That(request).HasRequestUri("https://github.com/aweXpect/aweXpect.Web");
+await Expect.That(request).HasRequestUri(new Uri("https://github.com/aweXpect/aweXpect.Web"));
+```
+
+You can use the same configuration options as
+when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
+
 ### Header
 
 You can verify the headers of the `HttpRequestMessage`:

--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ await Expect.That(request).HasRequestUri("https://github.com/aweXpect/aweXpect.W
 await Expect.That(request).HasRequestUri(new Uri("https://github.com/aweXpect/aweXpect.Web"));
 ```
 
-You can use the same configuration options as
-when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
-
 ### Header
 
 You can verify the headers of the `HttpRequestMessage`:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,30 @@ Web extensions for [aweXpect](https://github.com/aweXpect/aweXpect).
 
 ## `HttpRequestMessage`
 
+### Method
+
+You can verify, the method of the `HttpRequestMessage`:
+
+```csharp
+var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+
+await Expect.That(request).HasMethod(HttpMethod.Get);
+```
+
+### Request URI
+
+You can verify, the request URI of the `HttpRequestMessage`:
+
+```csharp
+var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+
+await Expect.That(request).HasRequestUri("https://github.com/aweXpect/aweXpect.Web");
+await Expect.That(request).HasRequestUri(new Uri("https://github.com/aweXpect/aweXpect.Web"));
+```
+
+You can use the same configuration options as
+when [comparing strings](https://awexpect.com/docs/expectations/string#equality).
+
 ### Header
 
 You can verify the headers of the `HttpRequestMessage`:

--- a/Source/aweXpect.Web/ThatHttpRequestMessage.HasMethod.cs
+++ b/Source/aweXpect.Web/ThatHttpRequestMessage.HasMethod.cs
@@ -1,0 +1,50 @@
+﻿using System.Net.Http;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatHttpRequestMessage
+{
+	/// <summary>
+	///     Verifies that the <see cref="HttpRequestMessage" /> has the <paramref name="expected" /> method.
+	/// </summary>
+	public static AndOrResult<HttpRequestMessage, IThat<HttpRequestMessage?>>
+		HasMethod(this IThat<HttpRequestMessage?> source, HttpMethod expected)
+		=> new(
+			source.ThatIs().ExpectationBuilder
+				.UpdateContexts(c => c.Close())
+				.AddConstraint((expectationBuilder, it, grammar) =>
+					new HasMethodConstraint(expectationBuilder, it, expected)),
+			source);
+
+	private readonly struct HasMethodConstraint(
+		ExpectationBuilder expectationBuilder,
+		string it,
+		HttpMethod expected)
+		: IValueConstraint<HttpRequestMessage>
+	{
+		public ConstraintResult IsMetBy(HttpRequestMessage? actual)
+		{
+			if (actual == null)
+			{
+				return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
+					$"{it} was <null>");
+			}
+
+			if (actual.Method != expected)
+			{
+				expectationBuilder.AddContext(actual);
+				return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
+					$"{it} was {actual.Method}");
+			}
+
+			return new ConstraintResult.Success<HttpRequestMessage?>(actual, ToString());
+		}
+
+		public override string ToString()
+			=> $"has a {expected} method";
+	}
+}

--- a/Source/aweXpect.Web/ThatHttpRequestMessage.HasRequestUri.cs
+++ b/Source/aweXpect.Web/ThatHttpRequestMessage.HasRequestUri.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Net.Http;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+public static partial class ThatHttpRequestMessage
+{
+	/// <summary>
+	///     Verifies that the <see cref="HttpRequestMessage" /> has the <paramref name="expected" />
+	///     <see cref="HttpRequestMessage.RequestUri" />.
+	/// </summary>
+	public static StringEqualityTypeResult<HttpRequestMessage, IThat<HttpRequestMessage?>>
+		HasRequestUri(this IThat<HttpRequestMessage?> source, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<HttpRequestMessage, IThat<HttpRequestMessage?>>(
+			source.ThatIs().ExpectationBuilder
+				.UpdateContexts(c => c.Close())
+				.AddConstraint((expectationBuilder, it, grammar) =>
+					new HasRequestUriConstraint(expectationBuilder, it, new Uri(expected).ToString(), options)),
+			source,
+			options);
+	}
+
+	/// <summary>
+	///     Verifies that the <see cref="HttpRequestMessage" /> has the <paramref name="expected" />
+	///     <see cref="HttpRequestMessage.RequestUri" />.
+	/// </summary>
+	public static StringEqualityTypeResult<HttpRequestMessage, IThat<HttpRequestMessage?>>
+		HasRequestUri(this IThat<HttpRequestMessage?> source, Uri expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<HttpRequestMessage, IThat<HttpRequestMessage?>>(
+			source.ThatIs().ExpectationBuilder
+				.UpdateContexts(c => c.Close())
+				.AddConstraint((expectationBuilder, it, grammar) =>
+					new HasRequestUriConstraint(expectationBuilder, it, expected.ToString(), options)),
+			source,
+			options);
+	}
+
+	private readonly struct HasRequestUriConstraint(
+		ExpectationBuilder expectationBuilder,
+		string it,
+		string expected,
+		StringEqualityOptions options)
+		: IValueConstraint<HttpRequestMessage>
+	{
+		public ConstraintResult IsMetBy(HttpRequestMessage? actual)
+		{
+			if (actual == null)
+			{
+				return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
+					$"{it} was <null>");
+			}
+
+			string? requestUri = actual.RequestUri?.ToString();
+			if (!options.AreConsideredEqual(requestUri, expected))
+			{
+				expectationBuilder.AddContext(actual);
+				return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
+					options.GetExtendedFailure(it, requestUri, expected));
+			}
+
+			return new ConstraintResult.Success<HttpRequestMessage?>(actual, ToString());
+		}
+
+		public override string ToString()
+			=> $"has a request URI {options.GetExpectation(expected, ExpectationGrammars.None)}";
+	}
+}

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -9,8 +9,8 @@ namespace aweXpect
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
         public static aweXpect.Web.Results.HasHeaderValueResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasHeader(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasMethod(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Net.Http.HttpMethod expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Uri expected) { }
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Uri expected) { }
     }
     public static class ThatHttpResponseMessage
     {

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -8,6 +8,9 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Action<aweXpect.Core.IThat<string?>> expectations) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
         public static aweXpect.Web.Results.HasHeaderValueResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasHeader(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasMethod(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Net.Http.HttpMethod expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Uri expected) { }
     }
     public static class ThatHttpResponseMessage
     {

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -9,8 +9,8 @@ namespace aweXpect
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
         public static aweXpect.Web.Results.HasHeaderValueResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasHeader(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasMethod(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Net.Http.HttpMethod expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Uri expected) { }
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Uri expected) { }
     }
     public static class ThatHttpResponseMessage
     {

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -8,6 +8,9 @@ namespace aweXpect
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Action<aweXpect.Core.IThat<string?>> expectations) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasContent(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
         public static aweXpect.Web.Results.HasHeaderValueResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasHeader(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasMethod(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Net.Http.HttpMethod expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Net.Http.HttpRequestMessage, aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?>> HasRequestUri(this aweXpect.Core.IThat<System.Net.Http.HttpRequestMessage?> source, System.Uri expected) { }
     }
     public static class ThatHttpResponseMessage
     {

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasMethod.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasMethod.Tests.cs
@@ -1,0 +1,61 @@
+﻿using System.Net.Http;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatHttpRequestMessage
+{
+	public sealed class HasMethod
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMethodDiffers_ShouldFail()
+			{
+				HttpRequestMessage subject = RequestBuilder
+					.WithMethod(HttpMethod.Get)
+					.WithUri("https://awexpect.com");
+
+				async Task Act()
+					=> await That(subject).HasMethod(HttpMethod.Post);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a POST method,
+					             but it was GET
+
+					             HTTP-Request:
+					               GET https://awexpect.com/ HTTP/1.1
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenMethodIsExpected_ShouldSucceed()
+			{
+				HttpRequestMessage subject = RequestBuilder
+					.WithMethod(HttpMethod.Get);
+
+				async Task Act()
+					=> await That(subject).HasMethod(HttpMethod.Get);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpRequestMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasMethod(HttpMethod.Delete);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a DELETE method,
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasRequestUri.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasRequestUri.Tests.cs
@@ -37,9 +37,12 @@ public sealed partial class ThatHttpRequestMessage
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has a request URI equal to "https://awexpect.com/awexpect.…",
-					             but it was "https://awexpect.com/" with a length of 21 which is shorter than the expected length of 33 and misses:
-					               "awexpect.Web"
+					             has a request URI equal to "https://awexpect.com/awexpect.Web",
+					             but it was "https://awexpect.com/" which differs at index 21:
+					                           ↓ (actual)
+					               "…xpect.com/"
+					               "…xpect.com/awexpect.Web"
+					                           ↑ (expected)
 
 					             HTTP-Request:
 					               GET https://awexpect.com/ HTTP/1.1

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasRequestUri.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasRequestUri.Tests.cs
@@ -1,0 +1,62 @@
+﻿using System.Net.Http;
+
+namespace aweXpect.Tests;
+
+public sealed partial class ThatHttpRequestMessage
+{
+	public sealed class HasRequestUri
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpRequestMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasRequestUri(new Uri("https://awexpect.com"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a request URI equal to "https://awexpect.com/",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenUriDiffers_ShouldFail()
+			{
+				HttpRequestMessage subject = RequestBuilder
+					.WithMethod(HttpMethod.Get)
+					.WithUri("https://awexpect.com");
+
+				async Task Act()
+					=> await That(subject).HasRequestUri("https://awexpect.com/awexpect.Web");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a request URI equal to "https://awexpect.com/awexpect.…",
+					             but it was "https://awexpect.com/" with a length of 21 which is shorter than the expected length of 33 and misses:
+					               "awexpect.Web"
+
+					             HTTP-Request:
+					               GET https://awexpect.com/ HTTP/1.1
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenUriIsExpected_ShouldSucceed()
+			{
+				HttpRequestMessage subject = RequestBuilder
+					.WithUri("https://awexpect.com");
+
+				async Task Act()
+					=> await That(subject).HasRequestUri("https://awexpect.com");
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Method

You can verify, the method of the `HttpRequestMessage`:

```csharp
var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");

await Expect.That(request).HasMethod(HttpMethod.Get);
```

### Request URI

You can verify, the request URI of the `HttpRequestMessage`:

```csharp
var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");

await Expect.That(request).HasRequestUri("https://github.com/aweXpect/aweXpect.Web");
await Expect.That(request).HasRequestUri(new Uri("https://github.com/aweXpect/aweXpect.Web"));
```

*Fixes #32*