### PR TITLE
fix: allow trailing commas in ProblemDetails

### DIFF
--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasProblemDetails.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasProblemDetails.cs
@@ -15,6 +15,11 @@ namespace aweXpect;
 
 public static partial class ThatHttpResponseMessage
 {
+	private static readonly JsonDocumentOptions _jsonDocumentOptions = new()
+	{
+		AllowTrailingCommas = true,
+	};
+
 	/// <summary>
 	///     Verifies that the string content contains a problem details response with the expected <paramref name="type" />.
 	///     <seealso href="https://datatracker.ietf.org/doc/html/rfc7807" />
@@ -37,7 +42,7 @@ public static partial class ThatHttpResponseMessage
 			source.ThatIs().ExpectationBuilder
 				.UpdateContexts(c => c.Close())
 				.AddConstraint((expectationBuilder, it, grammar) =>
-				new HasProblemDetailsConstraint(expectationBuilder, it, type, options, typeOptions)),
+					new HasProblemDetailsConstraint(expectationBuilder, it, type, options, typeOptions)),
 			source,
 			typeOptions,
 			options);
@@ -76,7 +81,7 @@ public static partial class ThatHttpResponseMessage
 #else
 			string message = await actual.Content.ReadAsStringAsync(cancellationToken);
 #endif
-			using JsonDocument problemDetails = JsonDocument.Parse(message);
+			using JsonDocument problemDetails = JsonDocument.Parse(message, _jsonDocumentOptions);
 			List<string> failures = new();
 
 			string? type = GetPropertyOrDefault(problemDetails.RootElement, "type")?.GetString();
@@ -122,7 +127,7 @@ public static partial class ThatHttpResponseMessage
 			{
 				expectationBuilder.AddContext(actual);
 				return new ConstraintResult.Failure<HttpResponseMessage?>(actual, ToString(),
-						string.Join($"{Environment.NewLine} and ", failures));
+					string.Join($"{Environment.NewLine} and ", failures));
 			}
 
 			return new ConstraintResult.Success<HttpResponseMessage?>(actual, ToString());

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithDetailTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithDetailTests.cs
@@ -69,12 +69,13 @@ public sealed partial class ThatHttpResponseMessage
 					.WithContent("""
 					             {
 					               "type": "my-type",
-					               "detail": "foo"
+					               "detail": "foo",
+					               "status": 200,
 					             }
 					             """);
 
 				async Task Act()
-					=> await That(subject).HasProblemDetails().WithDetail("foo");
+					=> await That(subject).HasProblemDetails().WithStatus(200).WithDetail("foo");
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithInstanceTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithInstanceTests.cs
@@ -69,12 +69,13 @@ public sealed partial class ThatHttpResponseMessage
 					.WithContent("""
 					             {
 					               "type": "my-type",
-					               "instance": "foo"
+					               "instance": "foo",
+					               "status": 200,
 					             }
 					             """);
 
 				async Task Act()
-					=> await That(subject).HasProblemDetails().WithInstance("foo");
+					=> await That(subject).HasProblemDetails().WithStatus(200).WithInstance("foo");
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithStatusTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithStatusTests.cs
@@ -53,7 +53,7 @@ public sealed partial class ThatHttpResponseMessage
 					             """);
 
 				async Task Act()
-					=> await That(subject).HasProblemDetails().WithStatus(500);
+					=> await That(subject).HasProblemDetails().WithStatus(500).WithStatus(500);
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithTitleTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithTitleTests.cs
@@ -69,12 +69,13 @@ public sealed partial class ThatHttpResponseMessage
 					.WithContent("""
 					             {
 					               "type": "my-type",
-					               "title": "foo"
+					               "title": "foo",
+					               "status": 200,
 					             }
 					             """);
 
 				async Task Act()
-					=> await That(subject).HasProblemDetails().WithTitle("foo");
+					=> await That(subject).HasProblemDetails().WithStatus(200).WithTitle("foo");
 
 				await That(Act).DoesNotThrow();
 			}


### PR DESCRIPTION
Support JSON structure with trailing commas when deserializing to `ProblemDetails` structure.