### PR TITLE
coverage: add internal tests for `HttpFormatter`

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -43,7 +43,11 @@ partial class Build
 			{
 				{
 					Solution.aweXpect_Web,
-					[Solution.Tests.aweXpect_Web_Tests, Solution.Tests.aweXpect_Web_Samples_Tests,]
+					[
+						Solution.Tests.aweXpect_Web_Tests,
+						Solution.Tests.aweXpect_Web_Internal_Tests,
+						Solution.Tests.aweXpect_Web_Samples_Tests,
+					]
 				},
 			};
 

--- a/Pipeline/Build.UnitTest.cs
+++ b/Pipeline/Build.UnitTest.cs
@@ -21,6 +21,7 @@ partial class Build
 	Project[] UnitTestProjects =>
 	[
 		Solution.Tests.aweXpect_Web_Tests,
+		Solution.Tests.aweXpect_Web_Internal_Tests,
 		Solution.Tests.aweXpect_Web_Samples_Tests,
 	];
 

--- a/Source/aweXpect.Web/Helpers/HttpFormatter.cs
+++ b/Source/aweXpect.Web/Helpers/HttpFormatter.cs
@@ -11,7 +11,7 @@ using aweXpect.Web.ContentProcessors;
 
 namespace aweXpect.Helpers;
 
-internal static class HttpResponseMessageFormatter
+internal static class HttpFormatter
 {
 	public static async Task<string> Format(
 		HttpRequestMessage? request,

--- a/Source/aweXpect.Web/Helpers/ThatExtensions.cs
+++ b/Source/aweXpect.Web/Helpers/ThatExtensions.cs
@@ -32,7 +32,7 @@ internal static class ThatExtensions
 			.Clear()
 			.Add(new ResultContext(HttpRequestContext,
 				async cancellationToken
-					=> await HttpResponseMessageFormatter.Format(request, "  ", cancellationToken)))
+					=> await HttpFormatter.Format(request, "  ", cancellationToken)))
 			.Close());
 
 	public static ExpectationBuilder AddContext(this ExpectationBuilder expectationBuilder,
@@ -45,7 +45,7 @@ internal static class ThatExtensions
 				.Clear()
 				.Add(new ResultContext(HttpResponseContext,
 					async cancellationToken
-						=> await HttpResponseMessageFormatter.Format(response, "  ", cancellationToken)))
+						=> await HttpFormatter.Format(response, "  ", cancellationToken)))
 				.Close());
 		}
 
@@ -54,10 +54,10 @@ internal static class ThatExtensions
 			.Clear()
 			.Add(new ResultContext(HttpRequestContext,
 				async cancellationToken
-					=> await HttpResponseMessageFormatter.Format(response.RequestMessage, "  ", cancellationToken)))
+					=> await HttpFormatter.Format(response.RequestMessage, "  ", cancellationToken)))
 			.Add(new ResultContext(HttpResponseContext,
 				async cancellationToken
-					=> await HttpResponseMessageFormatter.Format(response, "  ", cancellationToken)))
+					=> await HttpFormatter.Format(response, "  ", cancellationToken)))
 			.Close());
 	}
 }

--- a/Source/aweXpect.Web/aweXpect.Web.csproj
+++ b/Source/aweXpect.Web/aweXpect.Web.csproj
@@ -12,4 +12,8 @@
 		<PackageReference Include="System.Text.Json"/>
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="aweXpect.Web.Internal.Tests" PublicKey="$(PublicKey)"/>
+	</ItemGroup>
+
 </Project>

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -1,4 +1,5 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/aweXpect.Web.git")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"aweXpect.Web.Internal.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100bd818c7b1f408c9cae5e376d754fadbead7aa6046aaf3f4911a9c032c2ca4ccd46d6d2d5c9158a15a8639f34d6bfafc236c19e9158dd8fce375c43069256487d9be2dc05ab53fb90e3e9d8241c0ff0f70133bd74e88683ff1317b1b09ae6fd6ddc6fba1454e9d5487a97af791dd5fc73383f194b3be6e441e878a8691a1518e1")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace aweXpect
 {

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -1,4 +1,5 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/aweXpect.Web.git")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"aweXpect.Web.Internal.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100bd818c7b1f408c9cae5e376d754fadbead7aa6046aaf3f4911a9c032c2ca4ccd46d6d2d5c9158a15a8639f34d6bfafc236c19e9158dd8fce375c43069256487d9be2dc05ab53fb90e3e9d8241c0ff0f70133bd74e88683ff1317b1b09ae6fd6ddc6fba1454e9d5487a97af791dd5fc73383f194b3be6e441e878a8691a1518e1")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace aweXpect
 {

--- a/Tests/aweXpect.Web.Internal.Tests/Helpers/HttpFormatterTests.cs
+++ b/Tests/aweXpect.Web.Internal.Tests/Helpers/HttpFormatterTests.cs
@@ -1,0 +1,28 @@
+﻿using System.Net.Http;
+using System.Threading;
+using aweXpect.Helpers;
+
+namespace aweXpect.Web.Internal.Tests;
+
+public sealed class HttpFormatterTests
+{
+	[Fact]
+	public async Task Format_HttpRequestMessage_WhenNull_ShouldReturnNull()
+	{
+		HttpRequestMessage? sut = null;
+
+		string result = await HttpFormatter.Format(sut, "  ", CancellationToken.None);
+
+		await That(result).IsEqualTo("<null>");
+	}
+
+	[Fact]
+	public async Task Format_HttpResponseMessage_WhenNull_ShouldReturnNull()
+	{
+		HttpResponseMessage? sut = null;
+
+		string result = await HttpFormatter.Format(sut, "  ", CancellationToken.None);
+
+		await That(result).IsEqualTo("<null>");
+	}
+}

--- a/Tests/aweXpect.Web.Internal.Tests/Usings.cs
+++ b/Tests/aweXpect.Web.Internal.Tests/Usings.cs
@@ -1,0 +1,6 @@
+﻿global using System;
+global using System.Threading.Tasks;
+global using Xunit;
+global using Xunit.Sdk;
+global using aweXpect;
+global using static aweXpect.Expect;

--- a/Tests/aweXpect.Web.Internal.Tests/aweXpect.Web.Internal.Tests.csproj
+++ b/Tests/aweXpect.Web.Internal.Tests/aweXpect.Web.Internal.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\Source\aweXpect.Web\aweXpect.Web.csproj"/>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="System.Net.Http"/>
+	</ItemGroup>
+
+	<PropertyGroup>
+		<SignAssembly>True</SignAssembly>
+	</PropertyGroup>
+
+</Project>

--- a/aweXpect.Web.sln
+++ b/aweXpect.Web.sln
@@ -54,6 +54,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aweXpect.Web.Samples.Tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aweXpect.Web.Samples", "Source\aweXpect.Web.Samples\aweXpect.Web.Samples.csproj", "{94B10959-03DD-44C2-8E1B-40BA4B6A311B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aweXpect.Web.Internal.Tests", "Tests\aweXpect.Web.Internal.Tests\aweXpect.Web.Internal.Tests.csproj", "{22424BE8-7362-4941-AC44-72FD2928DD11}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,7 @@ Global
 		{494F4BA5-02EE-4656-9D5E-BF9BB25C49E8} = {9CC57AD0-4984-4618-96EA-01FFFCCD84FA}
 		{EA828A6C-5C01-4950-9F67-F53847CE3DDF} = {9CC57AD0-4984-4618-96EA-01FFFCCD84FA}
 		{A883F8D7-7F43-4ABA-B936-4EC075367C87} = {9CC57AD0-4984-4618-96EA-01FFFCCD84FA}
+		{22424BE8-7362-4941-AC44-72FD2928DD11} = {9CC57AD0-4984-4618-96EA-01FFFCCD84FA}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E122DD93-09CD-4316-A0D0-F57019A3B9B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -95,5 +98,9 @@ Global
 		{94B10959-03DD-44C2-8E1B-40BA4B6A311B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{94B10959-03DD-44C2-8E1B-40BA4B6A311B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{94B10959-03DD-44C2-8E1B-40BA4B6A311B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22424BE8-7362-4941-AC44-72FD2928DD11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22424BE8-7362-4941-AC44-72FD2928DD11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22424BE8-7362-4941-AC44-72FD2928DD11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22424BE8-7362-4941-AC44-72FD2928DD11}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Add separate test project with `InternalsVisibleTo` to allow tests for edge cases.