### PR TITLE
coverage: add missing test cases

### DIFF
--- a/Source/aweXpect.Web/Helpers/HttpContentExtensions.cs
+++ b/Source/aweXpect.Web/Helpers/HttpContentExtensions.cs
@@ -15,7 +15,7 @@ internal static class HttpContentExtensions
 
 		try
 		{
-			_ = content.Headers?.ContentLength;
+			_ = content.Headers.ContentLength;
 			return false;
 		}
 		catch (ObjectDisposedException)
@@ -28,7 +28,7 @@ internal static class HttpContentExtensions
 	{
 		try
 		{
-			length = content?.Headers?.ContentLength ?? 0;
+			length = content?.Headers.ContentLength ?? 0;
 			return true;
 		}
 		catch (Exception)
@@ -40,15 +40,7 @@ internal static class HttpContentExtensions
 
 	public static bool TryGetMediaType(this HttpContent? content, [NotNullWhen(true)] out string? contentType)
 	{
-		try
-		{
-			contentType = content?.Headers?.ContentType?.MediaType;
-			return contentType != null;
-		}
-		catch (Exception)
-		{
-			contentType = null;
-			return false;
-		}
+		contentType = content?.Headers.ContentType?.MediaType;
+		return contentType != null;
 	}
 }

--- a/Source/aweXpect.Web/Helpers/HttpFormatter.cs
+++ b/Source/aweXpect.Web/Helpers/HttpFormatter.cs
@@ -94,8 +94,7 @@ internal static class HttpFormatter
 		HttpHeaders headers,
 		string indentation)
 	{
-		foreach (KeyValuePair<string, IEnumerable<string>> header in headers
-			         .OrderBy(x => x.Key == "Content-Length"))
+		foreach (KeyValuePair<string, IEnumerable<string>> header in headers)
 		{
 			foreach (string headerValue in header.Value)
 			{

--- a/Source/aweXpect.Web/ThatHttpRequestMessage.HasContent.cs
+++ b/Source/aweXpect.Web/ThatHttpRequestMessage.HasContent.cs
@@ -69,6 +69,7 @@ public static partial class ThatHttpRequestMessage
 
 			if (actual.Content is null)
 			{
+				expectationBuilder.AddContext(actual);
 				return new ConstraintResult.Failure<HttpRequestMessage?>(actual, ToString(),
 					$"{it} had a <null> content");
 			}

--- a/Source/aweXpect.Web/Web/Results/HasHeaderValueResult.cs
+++ b/Source/aweXpect.Web/Web/Results/HasHeaderValueResult.cs
@@ -102,7 +102,7 @@ public class HasHeaderValueResult<TType, TThat>
 			if (headerValues.Length != 1)
 			{
 				return new ConstraintResult.Failure<TType?>(actual, ToString(),
-					$"the header contained {headerValues.Length} values");
+					$"the header contained {headerValues.Length} values {Formatter.Format(headerValues)}");
 			}
 
 			string? headerValue = headerValues[0];

--- a/Tests/aweXpect.Web.Internal.Tests/Helpers/HttpContentExtensionsTests.cs
+++ b/Tests/aweXpect.Web.Internal.Tests/Helpers/HttpContentExtensionsTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
+using aweXpect.Helpers;
+
+namespace aweXpect.Web.Internal.Tests;
+
+public sealed class HttpContentExtensionsTests
+{
+	[Fact]
+	public async Task IsNullOrDisposed_WhenNull_ShouldReturnTrue()
+	{
+		HttpContent? content = null;
+		bool result = content.IsNullOrDisposed();
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task TryGetContentLength_WhenDisposed_ShouldReturnFalse()
+	{
+		HttpContent content = new ByteArrayContent([]);
+		content.Dispose();
+
+		bool result = content.TryGetContentLength(out long length);
+
+		await That(result).IsFalse();
+		await That(length).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task TryGetContentLength_WhenEmpty_ShouldReturnTrue()
+	{
+		HttpContent content = new ByteArrayContent([]);
+
+		bool result = content.TryGetContentLength(out long length);
+
+		await That(result).IsTrue();
+		await That(length).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task TryGetMediaType_WhenDisposed_ShouldReturnMediaType()
+	{
+		HttpContent content = new StringContent("");
+		content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+		content.Dispose();
+
+		bool result = content.TryGetMediaType(out string? mediaType);
+
+		await That(result).IsTrue();
+		await That(mediaType).IsEqualTo("text/plain");
+	}
+}

--- a/Tests/aweXpect.Web.Internal.Tests/Helpers/HttpFormatterTests.cs
+++ b/Tests/aweXpect.Web.Internal.Tests/Helpers/HttpFormatterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using aweXpect.Helpers;
 
@@ -7,7 +8,7 @@ namespace aweXpect.Web.Internal.Tests;
 public sealed class HttpFormatterTests
 {
 	[Fact]
-	public async Task Format_HttpRequestMessage_WhenNull_ShouldReturnNull()
+	public async Task Format_HttpRequestMessage_WhenNull_ShouldReturnNullString()
 	{
 		HttpRequestMessage? sut = null;
 
@@ -17,7 +18,7 @@ public sealed class HttpFormatterTests
 	}
 
 	[Fact]
-	public async Task Format_HttpResponseMessage_WhenNull_ShouldReturnNull()
+	public async Task Format_HttpResponseMessage_WhenNull_ShouldReturnNullString()
 	{
 		HttpResponseMessage? sut = null;
 

--- a/Tests/aweXpect.Web.Internal.Tests/Helpers/StringExtensionsTests.cs
+++ b/Tests/aweXpect.Web.Internal.Tests/Helpers/StringExtensionsTests.cs
@@ -1,0 +1,57 @@
+﻿using aweXpect.Helpers;
+
+namespace aweXpect.Web.Internal.Tests;
+
+public sealed class StringExtensionsTests
+{
+	[Theory]
+	[InlineData(null)]
+	[InlineData("foo")]
+	public async Task Indent_WhenIndentationIsEmpty_ShouldReturnInput(string? input)
+	{
+		string? result = input.Indent("");
+
+		await That(result).IsEqualTo(input);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("foo")]
+	public async Task Indent_WhenIndentationIsNull_ShouldReturnInput(string? input)
+	{
+		string? result = input.Indent(null);
+
+		await That(result).IsEqualTo(input);
+	}
+
+	[Fact]
+	public async Task Indent_WhenNull_ShouldReturnNull()
+	{
+		string? input = null;
+
+		string? result = input.Indent();
+
+		await That(result).IsNull();
+	}
+
+	[Theory]
+	[InlineData(true, """
+	                    foo
+	                    bar
+	                  """)]
+	[InlineData(false, """
+	                   foo
+	                     bar
+	                   """)]
+	public async Task Indent_WithIndentFirstLine_ShouldReturnExpectedOutput(bool indentFirstLine, string expectedOutput)
+	{
+		string input = """
+		               foo
+		               bar
+		               """;
+
+		string? result = input.Indent(indentFirstLine: indentFirstLine);
+
+		await That(result).IsEqualTo(expectedOutput);
+	}
+}

--- a/Tests/aweXpect.Web.Tests/TestHelpers/HttpRequestBuilder.cs
+++ b/Tests/aweXpect.Web.Tests/TestHelpers/HttpRequestBuilder.cs
@@ -39,6 +39,12 @@ internal class HttpRequestBuilder
 		return this;
 	}
 
+	public HttpRequestBuilder WithContent(HttpContent content)
+	{
+		_content = content;
+		return this;
+	}
+
 	public HttpRequestBuilder WithHeader(string name, string value)
 	{
 		_headers.Add(name, value);

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WithValueTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasHeader.WithValueTests.cs
@@ -72,6 +72,26 @@ public sealed partial class ThatHttpResponseMessage
 			}
 
 			[Fact]
+			public async Task WhenHeaderExistsButContainsAdditionalValues_ShouldFail()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				string expectedValue = "some other header";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithHeaders(name, value, "some other value");
+
+				async Task Act()
+					=> await That(subject).HasHeader(name).WithValue(expectedValue);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-my-header` header whose value is equal to "some other header",
+					             but the header contained 2 values ["some header", "some other value"]
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				HttpResponseMessage? subject = null;


### PR DESCRIPTION
- Add context when the content of a `HttpRequestMessage` is null
- Add the header values when expecting only one and multiple exist
- Add tests for
  - `HttpContentExtensions`
  - `StringExtensions`
- Ensure that the `Content-Length` header is always the last