### PR TITLE
coverage: increase code coverage

### DIFF
--- a/Tests/aweXpect.Web.Internal.Tests/Helpers/HttpContentExtensionsTests.cs
+++ b/Tests/aweXpect.Web.Internal.Tests/Helpers/HttpContentExtensionsTests.cs
@@ -7,6 +7,17 @@ namespace aweXpect.Web.Internal.Tests;
 public sealed class HttpContentExtensionsTests
 {
 	[Fact]
+	public async Task IsNullOrDisposed_WhenDisposed_ShouldReturnTrue()
+	{
+		HttpContent content = new StringContent("");
+		content.Dispose();
+
+		bool result = content.IsNullOrDisposed();
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
 	public async Task IsNullOrDisposed_WhenNull_ShouldReturnTrue()
 	{
 		HttpContent? content = null;

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasContent.ExpectationsTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasContent.ExpectationsTests.cs
@@ -50,6 +50,25 @@ public sealed partial class ThatHttpRequestMessage
 			}
 
 			[Fact]
+			public async Task WhenContentIsNull_ShouldFail()
+			{
+				HttpRequestMessage subject = new(HttpMethod.Get, "https://awexpect.com");
+
+				async Task Act()
+					=> await That(subject).HasContent(which => which.IsEmpty());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a string content which is empty,
+					             but the string content was <null>
+
+					             HTTP-Request:
+					               GET https://awexpect.com/ HTTP/1.1
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				HttpRequestMessage? subject = null;

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.WithValueTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.WithValueTests.cs
@@ -33,6 +33,29 @@ public sealed partial class ThatHttpRequestMessage
 			}
 
 			[Fact]
+			public async Task WhenHeaderValueIsNull_ShouldFail()
+			{
+				string name = "x-my-header";
+				string otherKey = "x-some-other-key";
+				HttpRequestMessage subject = RequestBuilder
+					.WithHeader(name, null);
+
+				async Task Act()
+					=> await That(subject).HasHeader(otherKey).WithValue("some header");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has a `x-some-other-key` header whose value is equal to "some header",
+					             but it did not contain the expected header
+
+					             HTTP-Request:
+					               HEAD https://awexpect.com/ HTTP/1.1
+					                 x-my-header:
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenHeaderExistsAndValueDoesNotSatisfyTheExpectations_ShouldFail()
 			{
 				string name = "x-my-header";

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithStatusTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.WithStatusTests.cs
@@ -57,6 +57,37 @@ public sealed partial class ThatHttpResponseMessage
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenCheckingStatusDifferentlyTwice_ShouldFail()
+			{
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContent("""
+					             {
+					               "type": "my-type",
+					               "status": 500
+					             }
+					             """);
+
+				async Task Act()
+					=> await That(subject).HasProblemDetails().WithStatus(500).WithStatus(501);
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($$"""
+					               Expected that subject
+					               has a ProblemDetails content with any type, status 500 and status 501,
+					               but it had status 500
+
+					               HTTP-Response:
+					                 200 OK HTTP/1.1
+					                   Content-Type: text/plain; charset=utf-8
+					                   Content-Length: *
+					                 {
+					                   "type": "my-type",
+					                   "status": 500
+					                 }
+					               """).AsWildcard();
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.ErrorTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.ErrorTests.cs
@@ -9,6 +9,21 @@ public sealed partial class ThatHttpResponseMessage
 	{
 		public sealed class ErrorTests
 		{
+			[Fact]
+			public async Task WhenStatusCodeIs600_ShouldFail()
+			{
+				HttpStatusCode statusCode = (HttpStatusCode)600;
+				HttpResponseMessage subject = ResponseBuilder
+					.WithStatusCode(statusCode);
+
+				async Task Act()
+					=> await That(subject).HasStatusCode().Error();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*has an error status code (4xx or 5xx)*")
+					.AsWildcard();
+			}
+
 			[Theory]
 			[MemberData(nameof(ClientErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]
 			[MemberData(nameof(ServerErrorStatusCodes), MemberType = typeof(ThatHttpResponseMessage))]

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.ServerErrorTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasStatusCode.ServerErrorTests.cs
@@ -40,6 +40,21 @@ public sealed partial class ThatHttpResponseMessage
 			}
 
 			[Fact]
+			public async Task WhenStatusCodeIs600_ShouldFail()
+			{
+				HttpStatusCode statusCode = (HttpStatusCode)600;
+				HttpResponseMessage subject = ResponseBuilder
+					.WithStatusCode(statusCode);
+
+				async Task Act()
+					=> await That(subject).HasStatusCode().ServerError();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*has a server error status code (5xx)*")
+					.AsWildcard();
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsNull_ShouldFail()
 			{
 				HttpResponseMessage? subject = null;

--- a/Tests/aweXpect.Web.Tests/Web/ContentProcessor.JsonContentProcessorTests.cs
+++ b/Tests/aweXpect.Web.Tests/Web/ContentProcessor.JsonContentProcessorTests.cs
@@ -42,7 +42,7 @@ public sealed partial class ContentProcessor
 			string contentType)
 		{
 			HttpResponseMessage httpResponse = new HttpResponseBuilder()
-				.WithContent("{\"my-content\":1}")
+				.WithContent("{\"my-content\":1,}")
 				.WithContentType(contentType);
 
 			async Task Act()


### PR DESCRIPTION
Add tests for missing edge cases:
- `IsNullOrDisposed` for disposed `HttpContent`
- null content with expectation check
- null header value
- StatusCode 600 is not an error or a server error 