### PR TITLE
chore: support pull requests from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
                         8.0.x
                         9.0.x
             -   name: Run mutation tests
-                run: ./build.sh MutationTests
+                run: ./build.sh MutationTests MutationTestDashboard
     
     benchmarks:
         name: "Benchmarks"

--- a/.github/workflows/ci-analysis.yml
+++ b/.github/workflows/ci-analysis.yml
@@ -1,0 +1,54 @@
+name: CI-Analysis
+
+on:
+    workflow_dispatch:
+    workflow_run:
+        workflows: [ "CI" ]
+        types:
+            - completed
+
+jobs:
+    mutation-tests:
+        name: "Mutation tests"
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        env:
+            STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
+                with:
+                    dotnet-version: |
+                        8.0.x
+                        9.0.x
+            -   name: Upload mutation dashboard and create comment
+                run: ./build.sh MutationTestDashboard
+                env:
+                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+                    WorkflowRunId: ${{ github.event.workflow_run.id }}
+    
+    benchmarks:
+        name: "Benchmarks"
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
+                with:
+                    dotnet-version: |
+                        8.0.x
+                        9.0.x
+            -   name: Create benchmark comment
+                run: ./build.sh BenchmarkComment
+                env:
+                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+                    WorkflowRunId: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,8 @@ jobs:
     
     mutation-tests:
         name: "Mutation tests"
-        if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
-        permissions:
-            pull-requests: write
         env:
-            STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
             DOTNET_NOLOGO: true
         steps:
             -   uses: actions/checkout@v4
@@ -84,16 +80,17 @@ jobs:
                         9.0.x
             -   name: Run mutation tests
                 run: ./build.sh MutationTests
-                env:
-                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Upload artifacts
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: MutationTests
+                    path: |
+                        ./Artifacts/*
     
     benchmarks:
         name: "Benchmarks"
-        if: ${{ github.actor != 'dependabot[bot]' }}
         runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            pull-requests: write
         env:
             DOTNET_NOLOGO: true
         steps:
@@ -108,12 +105,17 @@ jobs:
                         9.0.x
             -   name: Run benchmarks
                 run: ./build.sh Benchmarks
-                env:
-                    GithubToken: ${{ secrets.GITHUB_TOKEN }}
+            -   name: Upload artifacts
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: Benchmarks
+                    path: |
+                        ./Artifacts/*
     
     static-code-analysis:
         name: "Static code analysis"
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name}}
         runs-on: ubuntu-latest
         env:
             REPORTGENERATOR_LICENSE: ${{ secrets.REPORTGENERATOR_LICENSE }}

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -39,6 +39,7 @@
         "DotNetFrameworkUnitTests",
         "DotNetUnitTests",
         "MutationComment",
+        "MutationTestDashboard",
         "MutationTestExecution",
         "MutationTests",
         "Pack",

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -45,8 +45,7 @@ partial class Build
 			Dictionary<Project, Project[]> projects = new()
 			{
 				{
-					Solution.aweXpect_Web,
-					[
+					Solution.aweXpect_Web, [
 						Solution.Tests.aweXpect_Web_Tests,
 						Solution.Tests.aweXpect_Web_Internal_Tests,
 						Solution.Tests.aweXpect_Web_Samples_Tests,
@@ -63,6 +62,7 @@ partial class Build
 					branchName = "release/" + version;
 					Log.Information("Use release branch analysis for '{BranchName}'", branchName);
 				}
+
 				File.WriteAllText(ArtifactsDirectory / "BranchName.txt", branchName);
 
 				string configText = $$"""
@@ -129,7 +129,7 @@ partial class Build
 			              + Environment.NewLine
 			              + MutationCommentBody;
 			File.WriteAllText(ArtifactsDirectory / "PR_Comment.md", body);
-			
+
 			if (prId != null)
 			{
 				File.WriteAllText(ArtifactsDirectory / "PR.txt", prId.Value.ToString());
@@ -145,23 +145,24 @@ partial class Build
 			Dictionary<Project, Project[]> projects = new()
 			{
 				{
-					Solution.aweXpect_Web,
-					[
+					Solution.aweXpect_Web, [
 						Solution.Tests.aweXpect_Web_Tests,
 						Solution.Tests.aweXpect_Web_Internal_Tests,
 						Solution.Tests.aweXpect_Web_Samples_Tests,
 					]
 				},
 			};
-			var apiKey = Environment.GetEnvironmentVariable("STRYKER_DASHBOARD_API_KEY");
-			var branchName = File.ReadAllText(ArtifactsDirectory / "BranchName.txt");
-			foreach (var project in projects)
+			string apiKey = Environment.GetEnvironmentVariable("STRYKER_DASHBOARD_API_KEY");
+			string branchName = File.ReadAllText(ArtifactsDirectory / "BranchName.txt");
+			foreach (KeyValuePair<Project, Project[]> project in projects)
 			{
-				var reportComment = File.ReadAllText(ArtifactsDirectory / "Stryker" / "reports" / "mutation-report.json");
-				using var client = new HttpClient();
+				string reportComment =
+					File.ReadAllText(ArtifactsDirectory / "Stryker" / "reports" / "mutation-report.json");
+				using HttpClient client = new();
 				client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
 				// https://stryker-mutator.io/docs/General/dashboard/#send-a-report-via-curl
-				await client.PutAsync($"https://dashboard.stryker-mutator.io/api/reports/github.com/aweXpect/aweXpect.Web/{branchName}?module={project.Key.Name}",
+				await client.PutAsync(
+					$"https://dashboard.stryker-mutator.io/api/reports/github.com/aweXpect/aweXpect.Web/{branchName}?module={project.Key.Name}",
 					new StringContent(reportComment, new MediaTypeHeaderValue("application/json")));
 			}
 

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using Nuke.Common;
 using Nuke.Common.IO;
@@ -10,6 +12,7 @@ using Nuke.Common.Tools.DotNet;
 using Octokit;
 using Serilog;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
+using ProductHeaderValue = Octokit.ProductHeaderValue;
 using Project = Nuke.Common.ProjectModel.Project;
 
 // ReSharper disable UnusedMember.Local
@@ -60,6 +63,7 @@ partial class Build
 					branchName = "release/" + version;
 					Log.Information("Use release branch analysis for '{BranchName}'", branchName);
 				}
+				File.WriteAllText(ArtifactsDirectory / "BranchName.txt", branchName);
 
 				string configText = $$"""
 				                      {
@@ -88,9 +92,8 @@ partial class Build
 				File.WriteAllText(configFile, configText);
 				Log.Debug($"Created '{configFile}':{Environment.NewLine}{configText}");
 
-				string arguments = IsServerBuild
-					? $"-f \"{configFile}\" -O \"{strykerOutputDirectory}\" -r \"Markdown\" -r \"Dashboard\" -r \"cleartext\""
-					: $"-f \"{configFile}\" -O \"{strykerOutputDirectory}\" -r \"Markdown\" -r \"cleartext\"";
+				string arguments =
+					$"-f \"{configFile}\" -O \"{strykerOutputDirectory}\" -r \"Markdown\" -r \"cleartext\" -r \"json\"";
 
 				string executable = EnvironmentInfo.IsWin ? "dotnet-stryker.exe" : "dotnet-stryker";
 				IProcess process = ProcessTasks.StartProcess(
@@ -111,7 +114,7 @@ partial class Build
 	Target MutationComment => _ => _
 		.After(MutationTestExecution)
 		.OnlyWhenDynamic(() => GitHubActions.IsPullRequest)
-		.Executes(async () =>
+		.Executes(() =>
 		{
 			int? prId = GitHubActions.PullRequestNumber;
 			Log.Debug("Pull request number: {PullRequestId}", prId);
@@ -125,34 +128,76 @@ partial class Build
 			              + $"[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Web%2Fpull/{prId}/merge)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Web/pull/{prId}/merge)"
 			              + Environment.NewLine
 			              + MutationCommentBody;
-
+			File.WriteAllText(ArtifactsDirectory / "PR_Comment.md", body);
+			
 			if (prId != null)
 			{
-				GitHubClient gitHubClient = new(new ProductHeaderValue("Nuke"));
-				Credentials tokenAuth = new(GithubToken);
-				gitHubClient.Credentials = tokenAuth;
-				IReadOnlyList<IssueComment> comments =
-					await gitHubClient.Issue.Comment.GetAllForIssue("aweXpect", "aweXpect.Web", prId.Value);
-				long? commentId = null;
-				Log.Information($"Found {comments.Count} comments");
-				foreach (IssueComment comment in comments)
-				{
-					if (comment.Body.Contains("## :alien: Mutation Results"))
-					{
-						Log.Information($"Found comment: {comment.Body}");
-						commentId = comment.Id;
-					}
-				}
+				File.WriteAllText(ArtifactsDirectory / "PR.txt", prId.Value.ToString());
+			}
+		});
 
-				if (commentId == null)
+	Target MutationTestDashboard => _ => _
+		.After(MutationTestExecution)
+		.Executes(async () =>
+		{
+			await "MutationTests".DownloadArtifactTo(ArtifactsDirectory, GithubToken);
+
+			Dictionary<Project, Project[]> projects = new()
+			{
 				{
-					Log.Information($"Create comment:\n{body}");
-					await gitHubClient.Issue.Comment.Create("aweXpect", "aweXpect.Web", prId.Value, body);
-				}
-				else
+					Solution.aweXpect_Web,
+					[
+						Solution.Tests.aweXpect_Web_Tests,
+						Solution.Tests.aweXpect_Web_Internal_Tests,
+						Solution.Tests.aweXpect_Web_Samples_Tests,
+					]
+				},
+			};
+			var apiKey = Environment.GetEnvironmentVariable("STRYKER_DASHBOARD_API_KEY");
+			var branchName = File.ReadAllText(ArtifactsDirectory / "BranchName.txt");
+			foreach (var project in projects)
+			{
+				var reportComment = File.ReadAllText(ArtifactsDirectory / "Stryker" / "reports" / "mutation-report.json");
+				using var client = new HttpClient();
+				client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+				// https://stryker-mutator.io/docs/General/dashboard/#send-a-report-via-curl
+				await client.PutAsync($"https://dashboard.stryker-mutator.io/api/reports/github.com/aweXpect/aweXpect.Web/{branchName}?module={project.Key.Name}",
+					new StringContent(reportComment, new MediaTypeHeaderValue("application/json")));
+			}
+
+			if (File.Exists(ArtifactsDirectory / "PR.txt"))
+			{
+				string prNumber = File.ReadAllText(ArtifactsDirectory / "PR.txt");
+				Log.Debug("Pull request number: {PullRequestId}", prNumber);
+				string body = File.ReadAllText(ArtifactsDirectory / "PR_Comment.md");
+				if (int.TryParse(prNumber, out int prId))
 				{
-					Log.Information($"Update comment:\n{body}");
-					await gitHubClient.Issue.Comment.Update("aweXpect", "aweXpect.Web", commentId.Value, body);
+					GitHubClient gitHubClient = new(new ProductHeaderValue("Nuke"));
+					Credentials tokenAuth = new(GithubToken);
+					gitHubClient.Credentials = tokenAuth;
+					IReadOnlyList<IssueComment> comments =
+						await gitHubClient.Issue.Comment.GetAllForIssue("aweXpect", "aweXpect.Web", prId);
+					long? commentId = null;
+					Log.Information($"Found {comments.Count} comments");
+					foreach (IssueComment comment in comments)
+					{
+						if (comment.Body.Contains("## :alien: Mutation Results"))
+						{
+							Log.Information($"Found comment: {comment.Body}");
+							commentId = comment.Id;
+						}
+					}
+
+					if (commentId == null)
+					{
+						Log.Information($"Create comment:\n{body}");
+						await gitHubClient.Issue.Comment.Create("aweXpect", "aweXpect.Weg", prId, body);
+					}
+					else
+					{
+						Log.Information($"Update comment:\n{body}");
+						await gitHubClient.Issue.Comment.Update("aweXpect", "aweXpect.Web", commentId.Value, body);
+					}
 				}
 			}
 		});

--- a/Pipeline/BuildExtensions.cs
+++ b/Pipeline/BuildExtensions.cs
@@ -1,4 +1,10 @@
 ﻿using System;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.Tools.GitVersion;
 using Nuke.Common.Tools.SonarScanner;
@@ -32,5 +38,60 @@ public static class BuildExtensions
 
 		Log.Information("Use branch analysis for '{BranchName}'", gitVersion.BranchName);
 		return settings.SetBranchName(gitVersion.BranchName);
+	}
+
+	public static async Task DownloadArtifactTo(this string artifactName, string artifactsDirectory, string githubToken)
+	{
+		string runId = Environment.GetEnvironmentVariable("WorkflowRunId");
+		if (string.IsNullOrEmpty(runId))
+		{
+			Log.Information("Skip downloading artifacts, because no 'WorkflowRunId' environment variable is set.");
+			return;
+		}
+
+		using HttpClient client = new();
+		client.DefaultRequestHeaders.UserAgent.ParseAdd("aweXpect");
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
+		HttpResponseMessage response = await client.GetAsync(
+			$"https://api.github.com/repos/aweXpect/aweXpect.Web/actions/runs/{runId}/artifacts");
+
+		string responseContent = await response.Content.ReadAsStringAsync();
+		if (!response.IsSuccessStatusCode)
+		{
+			throw new InvalidOperationException(
+				$"Could not find artifacts for run #{runId}': {responseContent}");
+		}
+
+		try
+		{
+			JsonDocument jsonDocument = JsonDocument.Parse(responseContent);
+			foreach (JsonElement artifact in jsonDocument.RootElement.GetProperty("artifacts").EnumerateArray())
+			{
+				string name = artifact.GetProperty("name").GetString()!;
+				if (name.Equals(artifactName, StringComparison.OrdinalIgnoreCase))
+				{
+					long artifactId = artifact.GetProperty("id").GetInt64();
+					HttpResponseMessage fileResponse = await client.GetAsync(
+						$"https://api.github.com/repos/aweXpect/aweXpect.Web/actions/artifacts/{artifactId}/zip");
+					if (fileResponse.IsSuccessStatusCode)
+					{
+						using ZipArchive archive = new(await fileResponse.Content.ReadAsStreamAsync());
+						archive.ExtractToDirectory(artifactsDirectory);
+						Log.Information(
+							$"Extracted artifact #{artifactId} with {archive.Entries.Count} entries to {artifactsDirectory}:\n - {string.Join("\n - ", archive.Entries.Select(entry => $"{entry.Name} ({entry.Length})"))}");
+					}
+					else
+					{
+						string fileResponseContent = await fileResponse.Content.ReadAsStringAsync();
+						throw new InvalidOperationException(
+							$"Could not download the artifacts with id #{artifactId}': {fileResponseContent}");
+					}
+				}
+			}
+		}
+		catch (JsonException e)
+		{
+			Log.Error($"Could not parse JSON: {e.Message}\n{responseContent}");
+		}
 	}
 }

--- a/aweXpect.Web.sln
+++ b/aweXpect.Web.sln
@@ -41,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\ci.yml = .github\workflows\ci.yml
+		.github\workflows\ci-analysis.yml = .github\workflows\ci-analysis.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{B776D4D9-F241-49BA-B005-8484BC686008}"


### PR DESCRIPTION
The build pipeline currently does not support pull requests from forks, as the secrets are not available. Follow the [recommendation from Github](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) and add a second build step with the `workflow_run` trigger.

As [SonarCloud does not support this](https://community.sonarsource.com/t/code-analysis-on-pull-request-from-forked-repository-with-github-actions/43986/4), disable static code analyis for pull requests from forked repositories.