### PR TITLE
fix: typo in build pipeline

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -192,7 +192,7 @@ partial class Build
 					if (commentId == null)
 					{
 						Log.Information($"Create comment:\n{body}");
-						await gitHubClient.Issue.Comment.Create("aweXpect", "aweXpect.Weg", prId, body);
+						await gitHubClient.Issue.Comment.Create("aweXpect", "aweXpect.Web", prId, body);
 					}
 					else
 					{

--- a/aweXpect.Web.sln
+++ b/aweXpect.Web.sln
@@ -67,9 +67,7 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2BD65F2F-F433-4C2D-8A7E-600039B3B7E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2BD65F2F-F433-4C2D-8A7E-600039B3B7E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2BD65F2F-F433-4C2D-8A7E-600039B3B7E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2BD65F2F-F433-4C2D-8A7E-600039B3B7E8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E122DD93-09CD-4316-A0D0-F57019A3B9B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E122DD93-09CD-4316-A0D0-F57019A3B9B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E122DD93-09CD-4316-A0D0-F57019A3B9B5}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Also fix the Nuke warning:
> Solution /home/runner/work/aweXpect.Web/aweXpect.Web/aweXpect.Web.sln has active build configurations for the build project.
    Either enable SuppressBuildProjectCheck on Build.Solution or remove the following entries from the solution file:
      - {2BD65F2F-F433-4C2D-8A7E-600039B3B7E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
      - {2BD65F2F-F433-4C2D-8A7E-600039B3B7E8}.Release|Any CPU.Build.0 = Release|Any CPU