### PR TITLE
feat: add negated expectations

### DIFF
--- a/Source/aweXpect.Web/ThatHttpRequestMessage.HasContent.cs
+++ b/Source/aweXpect.Web/ThatHttpRequestMessage.HasContent.cs
@@ -114,6 +114,10 @@ public static partial class ThatHttpRequestMessage
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+			=> stringBuilder.Append("does not have a string content ")
+				.Append(options.GetExpectation(expected, ExpectationGrammars.None));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(It).Append(" had");
 	}
 }

--- a/Source/aweXpect.Web/ThatHttpRequestMessage.HasMethod.cs
+++ b/Source/aweXpect.Web/ThatHttpRequestMessage.HasMethod.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -63,6 +62,9 @@ public static partial class ThatHttpRequestMessage
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+			=> stringBuilder.Append("does not have a ").Append(expected).Append(" method");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(It).Append(" had");
 	}
 }

--- a/Source/aweXpect.Web/ThatHttpRequestMessage.HasRequestUri.cs
+++ b/Source/aweXpect.Web/ThatHttpRequestMessage.HasRequestUri.cs
@@ -55,6 +55,7 @@ public static partial class ThatHttpRequestMessage
 				return this;
 			}
 
+			expectationBuilder.AddContext(actual);
 			_requestUri = actual.RequestUri?.ToString();
 			if (_requestUri?.Equals(expected, StringComparison.OrdinalIgnoreCase) == true)
 			{
@@ -62,13 +63,9 @@ public static partial class ThatHttpRequestMessage
 				return this;
 			}
 
-			expectationBuilder.AddContext(actual);
 			Outcome = Outcome.Failure;
 			return this;
 		}
-
-		public override string ToString()
-			=> $"has a request URI equal to {Formatter.Format(expected)}";
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -85,6 +82,12 @@ public static partial class ThatHttpRequestMessage
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+		{
+			stringBuilder.Append("does not have a request URI equal to ");
+			Formatter.Format(stringBuilder, expected);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(It).Append(" had");
 	}
 }

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasContent.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasContent.cs
@@ -107,6 +107,10 @@ public static partial class ThatHttpResponseMessage
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+			=> stringBuilder.Append("does not have a string content ")
+				.Append(options.GetExpectation(expected, ExpectationGrammars.None));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(It).Append(" had");
 	}
 }

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasContentType.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasContentType.cs
@@ -71,7 +71,8 @@ public static partial class ThatHttpResponseMessage
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("has a `Content-Type` header ").Append(options.GetExpectation(expected, Grammars));
+			=> stringBuilder.Append("has a `Content-Type` header ")
+				.Append(options.GetExpectation(expected, Grammars));
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -86,6 +87,10 @@ public static partial class ThatHttpResponseMessage
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+			=> stringBuilder.Append("does not have a `Content-Type` header ")
+				.Append(options.GetExpectation(expected, Grammars.Negate()));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(It).Append(" had");
 	}
 }

--- a/Source/aweXpect.Web/ThatHttpResponseMessage.HasProblemDetailsContent.cs
+++ b/Source/aweXpect.Web/ThatHttpResponseMessage.HasProblemDetailsContent.cs
@@ -160,6 +160,22 @@ public static partial class ThatHttpResponseMessage
 			=> stringBuilder.Append(string.Join($"{Environment.NewLine} and ", _failures));
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+		{
+			if (expectedType is null)
+			{
+				stringBuilder.Append("does not have a ProblemDetails content");
+			}
+			else
+			{
+				stringBuilder.Append("does not have a ProblemDetails content with type ");
+				Formatter.Format(stringBuilder, expectedType);
+				stringBuilder.Append(typeOptions);
+			}
+
+			stringBuilder.Append(options);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(It).Append(" had");
 	}
 }

--- a/Source/aweXpect.Web/Web/Results/HasHeaderValueResult.cs
+++ b/Source/aweXpect.Web/Web/Results/HasHeaderValueResult.cs
@@ -142,6 +142,12 @@ public class HasHeaderValueResult<TType, TThat>
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+		{
+			stringBuilder.Append(" whose value ");
+			stringBuilder.Append(options.GetExpectation(expected, Grammars | ExpectationGrammars.Active));
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(it).Append(" was");
 	}
 }

--- a/Source/aweXpect.Web/Web/Results/StatusCodeResult.cs
+++ b/Source/aweXpect.Web/Web/Results/StatusCodeResult.cs
@@ -174,6 +174,6 @@ public class StatusCodeResult(
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> throw new NotImplementedException();
+			=> throw new NotSupportedException();
 	}
 }

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasContent.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasContent.Tests.cs
@@ -115,5 +115,55 @@ public sealed partial class ThatHttpRequestMessage
 					             """);
 			}
 		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenContentDiffersFromExpected_ShouldSucceed()
+			{
+				string expected = "other content";
+				HttpRequestMessage subject = RequestBuilder
+					.WithContent("some content");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasContent(expected));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenContentEqualsExpected_ShouldFail()
+			{
+				string expected = "some content";
+				HttpRequestMessage subject = RequestBuilder
+					.WithContent(expected);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasContent(expected));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a string content equal to "some content",
+					             but it had
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpRequestMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasContent("some content"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a string content equal to "some content",
+					             but it was <null>
+					             """);
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.WhoseValueTests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasHeader.WhoseValueTests.cs
@@ -90,5 +90,60 @@ public sealed partial class ThatHttpRequestMessage
 					             """);
 			}
 		}
+
+		public sealed class NegatedWhoseValueTests
+		{
+			[Fact]
+			public async Task WhenHeaderDoesNotExist_ShouldSucceed()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				string otherKey = "x-some-other-key";
+				HttpRequestMessage subject = RequestBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject)
+						.DoesNotComplyWith(it => it.HasHeader(otherKey).WhoseValue(v => v.IsEqualTo(value)));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenHeaderExistsAndValueDoesNotSatisfyTheExpectations_ShouldSucceed()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				string expectedValue = "some other header";
+				HttpRequestMessage subject = RequestBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject)
+						.DoesNotComplyWith(it => it.HasHeader(name).WhoseValue(v => v.IsEqualTo(expectedValue)));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenHeaderExistsAndValueSatisfiesTheExpectations_ShouldFail()
+			{
+				string name = "x-my-header";
+				string value = "some header";
+				HttpRequestMessage subject = RequestBuilder
+					.WithHeader(name, value);
+
+				async Task Act()
+					=> await That(subject)
+						.DoesNotComplyWith(it => it.HasHeader(name).WhoseValue(v => v.IsEqualTo(value)));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a `x-my-header` header whose value is equal to "some header",
+					             but it did contain the `x-my-header` header: ["some header"]
+					             """);
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasMethod.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasMethod.Tests.cs
@@ -57,5 +57,54 @@ public sealed partial class ThatHttpRequestMessage
 					             """);
 			}
 		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenMethodDiffers_ShouldSucceed()
+			{
+				HttpRequestMessage subject = RequestBuilder
+					.WithMethod(HttpMethod.Get)
+					.WithUri("https://awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasMethod(HttpMethod.Post));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsExpected_ShouldFail()
+			{
+				HttpRequestMessage subject = RequestBuilder
+					.WithMethod(HttpMethod.Put);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasMethod(HttpMethod.Put));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a PUT method,
+					             but it had
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpRequestMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasMethod(HttpMethod.Delete));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a DELETE method,
+					             but it was <null>
+					             """);
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasRequestUri.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpRequestMessage.HasRequestUri.Tests.cs
@@ -61,5 +61,55 @@ public sealed partial class ThatHttpRequestMessage
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpRequestMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasRequestUri(new Uri("https://awexpect.com")));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a request URI equal to "https://awexpect.com/",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenUriDiffers_ShouldSucceed()
+			{
+				HttpRequestMessage subject = RequestBuilder
+					.WithMethod(HttpMethod.Get)
+					.WithUri("https://awexpect.com");
+
+				async Task Act()
+					=> await That(subject)
+						.DoesNotComplyWith(it => it.HasRequestUri("https://awexpect.com/awexpect.Web"));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenUriIsExpected_ShouldFail()
+			{
+				HttpRequestMessage subject = RequestBuilder
+					.WithUri("https://awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasRequestUri("https://awexpect.com"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a request URI equal to "https://awexpect.com/",
+					             but it had
+					             """);
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContent.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContent.Tests.cs
@@ -65,5 +65,55 @@ public sealed partial class ThatHttpResponseMessage
 					             """);
 			}
 		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenContentDiffersFromExpected_ShouldSucceed()
+			{
+				string expected = "other content";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContent("some content");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasContent(expected));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenContentEqualsExpected_ShouldFail()
+			{
+				string expected = "some content";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContent(expected);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasContent(expected));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a string content equal to "some content",
+					             but it had
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNull_ShouldFail()
+			{
+				HttpResponseMessage? subject = null;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasContent("some content"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a string content equal to "some content",
+					             but it was <null>
+					             """);
+			}
+		}
 	}
 }

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContentType.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasContentType.Tests.cs
@@ -10,19 +10,6 @@ public sealed partial class ThatHttpResponseMessage
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenContentEqualsExpected_ShouldSucceed()
-			{
-				string expected = "some/content";
-				HttpResponseMessage subject = ResponseBuilder
-					.WithContentType(expected);
-
-				async Task Act()
-					=> await That(subject).HasContentType(expected);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task WhenContentTypeDiffersFromExpected_ShouldFail()
 			{
 				string expected = "text/content-type";
@@ -48,6 +35,19 @@ public sealed partial class ThatHttpResponseMessage
 					                 Content-Type: text/other-content-type
 					               some content
 					             """);
+			}
+
+			[Fact]
+			public async Task WhenContentTypeEqualsExpected_ShouldSucceed()
+			{
+				string expected = "some/content";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContentType(expected);
+
+				async Task Act()
+					=> await That(subject).HasContentType(expected);
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -86,6 +86,54 @@ public sealed partial class ThatHttpResponseMessage
 					             has a `Content-Type` header equal to "some content" ignoring case,
 					             but it was <null>
 					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenContentTypeDiffersFromExpected_ShouldFail()
+			{
+				string expected = "text/content-type";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContentType("text/other-content-type")
+					.WithContent("some content");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasContentType(expected));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenContentTypeEqualsExpected_ShouldFail()
+			{
+				string expected = "some/content-type";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContentType(expected);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasContentType(expected));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a `Content-Type` header equal to "some/content-type",
+					             but it had
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenContentTypeHeaderIsNotSet_ShouldSucceed()
+			{
+				string expected = "text/content-type";
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContent(new StreamContent(new MemoryStream([0x0, 0x1,])));
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasContentType(expected));
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatHttpResponseMessage.HasProblemDetails.Tests.cs
@@ -166,5 +166,47 @@ public sealed partial class ThatHttpResponseMessage
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("foo", "bar")]
+			[InlineData("foo", "FOO")]
+			public async Task WhenTypeDoesNotMatch_ShouldSucceed(string actualType, string expectedType)
+			{
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContent($$"""
+					               {
+					                 "type": "{{actualType}}"
+					               }
+					               """);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasProblemDetailsContent(expectedType));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeMatches_ShouldFail()
+			{
+				HttpResponseMessage subject = ResponseBuilder
+					.WithContent("""
+					             {
+					               "type": "foo"
+					             }
+					             """);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasProblemDetailsContent("foo"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not have a ProblemDetails content with type "foo",
+					             but it had
+					             """);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Support `DoesNotComplyWith` for all expectation constraints in aweXpect.Web.