### PR TITLE
feat: add expectations on `Uri`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="aweXpect" Version="2.23.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.21.1" />
+    <PackageVersion Include="aweXpect.Core" Version="2.21.2" />
     <PackageVersion Include="aweXpect.Json" Version="1.4.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="9.0.2" />

--- a/Source/aweXpect.Web/ThatUri.HasDefaultPort.cs
+++ b/Source/aweXpect.Web/ThatUri.HasDefaultPort.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+#nullable enable
+public static partial class ThatUri
+{
+	/// <summary>
+	///     Verifies that the subject has the default port for the used scheme.
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.IsDefaultPort" />
+	/// </remarks>
+	public static AndOrResult<Uri, IThat<Uri>> HasDefaultPort(this IThat<Uri> source)
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new HasDefaultPortConstraint(it, grammars)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject does not have the default port for the used scheme.
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.IsDefaultPort" />
+	/// </remarks>
+	public static AndOrResult<Uri, IThat<Uri>> DoesNotHaveDefaultPort(this IThat<Uri> source)
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new HasDefaultPortConstraint(it, grammars).Invert()),
+			source);
+
+	private sealed class HasDefaultPortConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<Uri>(grammars),
+			IValueConstraint<Uri>
+	{
+		public ConstraintResult IsMetBy(Uri actual)
+		{
+			Actual = actual;
+			Outcome = actual.IsDefaultPort ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has the default port for the used scheme");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have the default port for the used scheme");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Web/ThatUri.IsAbsolute.cs
+++ b/Source/aweXpect.Web/ThatUri.IsAbsolute.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+#nullable enable
+public static partial class ThatUri
+{
+	/// <summary>
+	///     Verifies that the subject is an absolute URI.
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.IsAbsoluteUri" />
+	/// </remarks>
+	public static AndOrResult<Uri, IThat<Uri>> IsAbsolute(this IThat<Uri> source)
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsAbsoluteConstraint(it, grammars)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not an absolute URI.
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.IsAbsoluteUri" />
+	/// </remarks>
+	public static AndOrResult<Uri, IThat<Uri>> IsNotAbsolute(this IThat<Uri> source)
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsAbsoluteConstraint(it, grammars).Invert()),
+			source);
+
+	private sealed class IsAbsoluteConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<Uri>(grammars),
+			IValueConstraint<Uri>
+	{
+		public ConstraintResult IsMetBy(Uri actual)
+		{
+			Actual = actual;
+			Outcome = actual.IsAbsoluteUri ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is an absolute URI");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is not an absolute URI");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Web/ThatUri.IsFile.cs
+++ b/Source/aweXpect.Web/ThatUri.IsFile.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+#nullable enable
+public static partial class ThatUri
+{
+	/// <summary>
+	///     Verifies that the subject is a file URI.
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.IsFile" />
+	/// </remarks>
+	public static AndOrResult<Uri, IThat<Uri>> IsFile(this IThat<Uri> source)
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsFileConstraint(it, grammars)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not a file URI.
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.IsFile" />
+	/// </remarks>
+	public static AndOrResult<Uri, IThat<Uri>> IsNotFile(this IThat<Uri> source)
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsFileConstraint(it, grammars).Invert()),
+			source);
+
+	private sealed class IsFileConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<Uri>(grammars),
+			IValueConstraint<Uri>
+	{
+		public ConstraintResult IsMetBy(Uri actual)
+		{
+			Actual = actual;
+			Outcome = actual.IsFile ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is a file URI");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is not a file URI");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Web/ThatUri.IsLoopback.cs
+++ b/Source/aweXpect.Web/ThatUri.IsLoopback.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+#nullable enable
+public static partial class ThatUri
+{
+	/// <summary>
+	///     Verifies that the subject references the local host.
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.IsLoopback" />
+	/// </remarks>
+	public static AndOrResult<Uri, IThat<Uri>> IsLoopback(this IThat<Uri> source)
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsLoopbackConstraint(it, grammars)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject does not reference the local host.
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.IsLoopback" />
+	/// </remarks>
+	public static AndOrResult<Uri, IThat<Uri>> IsNotLoopback(this IThat<Uri> source)
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsLoopbackConstraint(it, grammars).Invert()),
+			source);
+
+	private sealed class IsLoopbackConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<Uri>(grammars),
+			IValueConstraint<Uri>
+	{
+		public ConstraintResult IsMetBy(Uri actual)
+		{
+			Actual = actual;
+			Outcome = actual.IsLoopback ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("references the local host");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not reference the local host");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Web/ThatUri.IsUnc.cs
+++ b/Source/aweXpect.Web/ThatUri.IsUnc.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+#nullable enable
+public static partial class ThatUri
+{
+	/// <summary>
+	///     Verifies that the subject is an UNC path.
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.IsUnc" />
+	/// </remarks>
+	public static AndOrResult<Uri, IThat<Uri>> IsUnc(this IThat<Uri> source)
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsUncConstraint(it, grammars)),
+			source);
+
+	/// <summary>
+	///     Verifies that the subject is not an UNC path.
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.IsUnc" />
+	/// </remarks>
+	public static AndOrResult<Uri, IThat<Uri>> IsNotUnc(this IThat<Uri> source)
+		=> new(source.Get().ExpectationBuilder.AddConstraint((it, grammars) =>
+				new IsUncConstraint(it, grammars).Invert()),
+			source);
+
+	private sealed class IsUncConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithValue<Uri>(grammars),
+			IValueConstraint<Uri>
+	{
+		public ConstraintResult IsMetBy(Uri actual)
+		{
+			Actual = actual;
+			Outcome = actual.IsUnc ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is an UNC path");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" was ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is not an UNC path");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Web/ThatUri.cs
+++ b/Source/aweXpect.Web/ThatUri.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace aweXpect;
+
+/// <summary>
+///     Expectations on <see cref="Uri" /> values.
+/// </summary>
+public static partial class ThatUri;

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -25,6 +25,19 @@ namespace aweXpect
         public static aweXpect.Web.Results.StatusCodeResult HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage?, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Net.HttpStatusCode? expected) { }
     }
+    public static class ThatUri
+    {
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> DoesNotHaveDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> HasDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsAbsolute(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsFile(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsLoopback(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotAbsolute(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotFile(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotLoopback(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotUnc(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsUnc(this aweXpect.Core.IThat<System.Uri> source) { }
+    }
 }
 namespace aweXpect.Web.ContentProcessors
 {

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -25,6 +25,19 @@ namespace aweXpect
         public static aweXpect.Web.Results.StatusCodeResult HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source) { }
         public static aweXpect.Results.AndOrResult<System.Net.Http.HttpResponseMessage?, aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?>> HasStatusCode(this aweXpect.Core.IThat<System.Net.Http.HttpResponseMessage?> source, System.Net.HttpStatusCode? expected) { }
     }
+    public static class ThatUri
+    {
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> DoesNotHaveDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> HasDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsAbsolute(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsFile(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsLoopback(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotAbsolute(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotFile(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotLoopback(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsNotUnc(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsUnc(this aweXpect.Core.IThat<System.Uri> source) { }
+    }
 }
 namespace aweXpect.Web.ContentProcessors
 {

--- a/Tests/aweXpect.Web.Tests/ThatUri.DoesNotHaveDefaultPort.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.DoesNotHaveDefaultPort.Tests.cs
@@ -1,0 +1,77 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class DoesNotHaveDefaultPort
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData("https://www.awexpect.com:80")]
+			[InlineData("http://www.example.com:443")]
+			public async Task WhenSubjectDoesNotHaveTheDefaultPort_ShouldSucceed(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotHaveDefaultPort();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("https://www.awexpect.com")]
+			[InlineData("https://www.awexpect.com:443")]
+			[InlineData("http://www.example.com:80")]
+			public async Task WhenSubjectHasTheDefaultPort_ShouldFail(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotHaveDefaultPort();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              does not have the default port for the used scheme,
+					              but it was {subject}
+					              """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("https://www.awexpect.com:80")]
+			[InlineData("http://www.example.com:443")]
+			public async Task WhenSubjectDoesNotHaveTheDefaultPort_ShouldFail(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.DoesNotHaveDefaultPort());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has the default port for the used scheme,
+					              but it was {subject}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("https://www.awexpect.com")]
+			[InlineData("https://www.awexpect.com:443")]
+			[InlineData("http://www.example.com:80")]
+			public async Task WhenSubjectHasTheDefaultPort_ShouldSucceed(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.DoesNotHaveDefaultPort());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatUri.HasDefaultPort.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.HasDefaultPort.Tests.cs
@@ -1,0 +1,77 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class HasDefaultPort
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData("https://www.awexpect.com:80")]
+			[InlineData("http://www.example.com:443")]
+			public async Task WhenSubjectDoesNotHaveTheDefaultPort_ShouldFail(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).HasDefaultPort();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has the default port for the used scheme,
+					              but it was {subject}
+					              """);
+			}
+
+			[Theory]
+			[InlineData("https://www.awexpect.com")]
+			[InlineData("https://www.awexpect.com:443")]
+			[InlineData("http://www.example.com:80")]
+			public async Task WhenSubjectHasTheDefaultPort_ShouldSucceed(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).HasDefaultPort();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("https://www.awexpect.com:80")]
+			[InlineData("http://www.example.com:443")]
+			public async Task WhenSubjectDoesNotHaveTheDefaultPort_ShouldSucceed(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasDefaultPort());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("https://www.awexpect.com")]
+			[InlineData("https://www.awexpect.com:443")]
+			[InlineData("http://www.example.com:80")]
+			public async Task WhenSubjectHasTheDefaultPort_ShouldFail(string uriString)
+			{
+				Uri subject = new(uriString);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasDefaultPort());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              does not have the default port for the used scheme,
+					              but it was {subject}
+					              """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatUri.IsAbsolute.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.IsAbsolute.Tests.cs
@@ -1,0 +1,69 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsAbsolute
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAbsolute_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsAbsolute();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAbsolute_ShouldFail()
+			{
+				Uri subject = new Uri("https://www.awexpect.com")
+					.MakeRelativeUri(new Uri("https://www.awexpect.com/foo/bar"));
+
+				async Task Act()
+					=> await That(subject).IsAbsolute();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an absolute URI,
+					             but it was foo/bar
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAbsolute_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsAbsolute());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not an absolute URI,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAbsolute_ShouldSucceed()
+			{
+				Uri subject = new Uri("https://www.awexpect.com")
+					.MakeRelativeUri(new Uri("https://www.awexpect.com/foo/bar"));
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsAbsolute());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatUri.IsFile.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.IsFile.Tests.cs
@@ -1,0 +1,67 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsFile
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAFileUri_ShouldSucceed()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).IsFile();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAFileUri_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsFile();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is a file URI,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAFileUri_ShouldFail()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsFile());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not a file URI,
+					             but it was file://server/filename.ext
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAFileUri_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsFile());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatUri.IsLoopback.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.IsLoopback.Tests.cs
@@ -1,0 +1,73 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsLoopback
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData("127.0.0.1")]
+			[InlineData("loopback")]
+			[InlineData("localhost")]
+			public async Task WhenSubjectIsLoopback_ShouldSucceed(string uriString)
+			{
+				Uri subject = new UriBuilder(uriString).Uri;
+
+				async Task Act()
+					=> await That(subject).IsLoopback();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotLoopback_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsLoopback();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             references the local host,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Theory]
+			[InlineData("127.0.0.1")]
+			[InlineData("loopback")]
+			[InlineData("localhost")]
+			public async Task WhenSubjectIsLoopback_ShouldFail(string uriString)
+			{
+				Uri subject = new UriBuilder(uriString).Uri;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsLoopback());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              does not reference the local host,
+					              but it was {subject}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotLoopback_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsLoopback());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatUri.IsNotAbsolute.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.IsNotAbsolute.Tests.cs
@@ -1,0 +1,69 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsNotAbsolute
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAbsolute_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsNotAbsolute();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not an absolute URI,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAbsolute_ShouldSucceed()
+			{
+				Uri subject = new Uri("https://www.awexpect.com")
+					.MakeRelativeUri(new Uri("https://www.awexpect.com/foo/bar"));
+
+				async Task Act()
+					=> await That(subject).IsNotAbsolute();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAbsolute_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotAbsolute());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAbsolute_ShouldFail()
+			{
+				Uri subject = new Uri("https://www.awexpect.com")
+					.MakeRelativeUri(new Uri("https://www.awexpect.com/foo/bar"));
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotAbsolute());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an absolute URI,
+					             but it was foo/bar
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatUri.IsNotFile.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.IsNotFile.Tests.cs
@@ -1,0 +1,67 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsNotFile
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAFileUri_ShouldFail()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).IsNotFile();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not a file URI,
+					             but it was file://server/filename.ext
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAFileUri_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsNotFile();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsAFileUri_ShouldSucceed()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotFile());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotAFileUri_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotFile());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is a file URI,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatUri.IsNotLoopback.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.IsNotLoopback.Tests.cs
@@ -1,0 +1,73 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsNotLoopback
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[InlineData("127.0.0.1")]
+			[InlineData("loopback")]
+			[InlineData("localhost")]
+			public async Task WhenSubjectIsNotLoopback_ShouldFail(string uriString)
+			{
+				Uri subject = new UriBuilder(uriString).Uri;
+
+				async Task Act()
+					=> await That(subject).IsNotLoopback();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              does not reference the local host,
+					              but it was {subject}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotLoopback_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsNotLoopback();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNotLoopback_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotLoopback());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             references the local host,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+
+			[Theory]
+			[InlineData("127.0.0.1")]
+			[InlineData("loopback")]
+			[InlineData("localhost")]
+			public async Task WhenSubjectIsNotLoopback_ShouldSucceed(string uriString)
+			{
+				Uri subject = new UriBuilder(uriString).Uri;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotLoopback());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatUri.IsNotUnc.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.IsNotUnc.Tests.cs
@@ -1,0 +1,67 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsNotUnc
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldFail()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).IsNotUnc();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not an UNC path,
+					             but it was file://server/filename.ext
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsNotUnc();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotUnc());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an UNC path,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldSucceed()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsNotUnc());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatUri.IsUnc.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.IsUnc.Tests.cs
@@ -1,0 +1,67 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class IsUnc
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).IsUnc();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is an UNC path,
+					             but it was https://www.awexpect.com/
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsUnc_ShouldSucceed()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).IsUnc();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSubjectIsNotUnc_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsUnc());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSubjectIsUnc_ShouldFail()
+			{
+				Uri subject = new("file://server/filename.ext");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsUnc());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not an UNC path,
+					             but it was file://server/filename.ext
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Web.Tests/ThatUri.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.cs
@@ -1,0 +1,4 @@
+﻿namespace aweXpect.Tests;
+
+// ReSharper disable once ClassNeverInstantiated.Global
+public sealed partial class ThatUri;


### PR DESCRIPTION
This PR adds Uri expectations to the aweXpect.Web library, introducing several extension methods to validate various Uri properties and states.

### Key changes
- Added Uri-specific assertion methods for absolute, file, loopback, and UNC path validation
  - `ThatUri.Is{Not}Absolute()`
  - `ThatUri.Is{Not}File()`
  - `ThatUri.Is{Not}Loopback()`
  - `ThatUri.Is{Not}Unc()`
- Added port validation methods for checking default port usage
  - `ThatUri.HasDefaultPort()` / `ThatUri.DoesNotHaveDefaultPort()`
- See also https://github.com/aweXpect/aweXpect/pull/782