### PR TITLE
chore: bump aweXpect

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="aweXpect" Version="2.23.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.21.2" />
+    <PackageVersion Include="aweXpect" Version="2.25.0" />
+    <PackageVersion Include="aweXpect.Core" Version="2.22.2" />
     <PackageVersion Include="aweXpect.Json" Version="1.4.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="9.0.2" />


### PR DESCRIPTION
This PR updates the aweXpect testing framework packages to newer versions, specifically bumping the main aweXpect package from 2.23.0 to 2.25.0 and aweXpect.Core from 2.21.2 to 2.22.2.