### PR TITLE
feat: add `HasScheme` for `Uri`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="aweXpect" Version="2.25.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.22.2" />
+    <PackageVersion Include="aweXpect.Core" Version="2.23.0" />
     <PackageVersion Include="aweXpect.Json" Version="1.4.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="9.0.2" />

--- a/Source/aweXpect.Web/ThatUri.HasScheme.cs
+++ b/Source/aweXpect.Web/ThatUri.HasScheme.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using aweXpect.Core;
+using aweXpect.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect;
+
+#nullable enable
+public static partial class ThatUri
+{
+	/// <summary>
+	///     Verifies that the scheme of the <see cref="Uri" /> subject…
+	/// </summary>
+	/// <remarks>
+	///     <seealso cref="Uri.Scheme" />
+	/// </remarks>
+	public static PropertyResult.String<Uri> HasScheme(this IThat<Uri> source)
+		=> new(source, u => u.Scheme, "scheme");
+}

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -29,6 +29,7 @@ namespace aweXpect
     {
         public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> DoesNotHaveDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
         public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> HasDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.PropertyResult.String<System.Uri> HasScheme(this aweXpect.Core.IThat<System.Uri> source) { }
         public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsAbsolute(this aweXpect.Core.IThat<System.Uri> source) { }
         public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsFile(this aweXpect.Core.IThat<System.Uri> source) { }
         public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsLoopback(this aweXpect.Core.IThat<System.Uri> source) { }

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -29,6 +29,7 @@ namespace aweXpect
     {
         public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> DoesNotHaveDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
         public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> HasDefaultPort(this aweXpect.Core.IThat<System.Uri> source) { }
+        public static aweXpect.Results.PropertyResult.String<System.Uri> HasScheme(this aweXpect.Core.IThat<System.Uri> source) { }
         public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsAbsolute(this aweXpect.Core.IThat<System.Uri> source) { }
         public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsFile(this aweXpect.Core.IThat<System.Uri> source) { }
         public static aweXpect.Results.AndOrResult<System.Uri, aweXpect.Core.IThat<System.Uri>> IsLoopback(this aweXpect.Core.IThat<System.Uri> source) { }

--- a/Tests/aweXpect.Web.Tests/ThatUri.HasScheme.Tests.cs
+++ b/Tests/aweXpect.Web.Tests/ThatUri.HasScheme.Tests.cs
@@ -1,0 +1,148 @@
+﻿namespace aweXpect.Tests;
+
+public sealed partial class ThatUri
+{
+	public sealed class HasScheme
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task Containing_WhenSubjectSchemeContainsTheExpectedValue_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com:80");
+
+				async Task Act()
+					=> await That(subject).HasScheme().Containing("http");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task EqualTo_WhenSubjectDoesNotEqualTheExpectedScheme_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com:80");
+
+				async Task Act()
+					=> await That(subject).HasScheme().EqualTo("http");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has scheme equal to "http",
+					             but it had scheme "https"
+					             """);
+			}
+
+			[Fact]
+			public async Task EqualTo_WhenSubjectEqualsExpectedScheme_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com:80");
+
+				async Task Act()
+					=> await That(subject).HasScheme().EqualTo("https");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task NotEqualTo_WhenSubjectDoesNotEqualTheExpectedScheme_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com:80");
+
+				async Task Act()
+					=> await That(subject).HasScheme().NotEqualTo("https");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has scheme not equal to "https",
+					             but it had scheme "https"
+					             """);
+			}
+
+			[Fact]
+			public async Task NotEqualTo_WhenSubjectEqualsExpectedScheme_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com:80");
+
+				async Task Act()
+					=> await That(subject).HasScheme().NotEqualTo("http");
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task Containing_WhenSubjectSchemeContainsTheExpectedValue_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com:80");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasScheme().Containing("http"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has scheme not containing "http",
+					             but it had scheme "https"
+					             """);
+			}
+
+			[Fact]
+			public async Task EqualTo_WhenSubjectDoesNotEqualTheExpectedScheme_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com:80");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasScheme().EqualTo("http"));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task EqualTo_WhenSubjectEqualsExpectedScheme_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com:80");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasScheme().EqualTo("https"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has scheme not equal to "https",
+					             but it had scheme "https"
+					             """);
+			}
+
+			[Fact]
+			public async Task NotEqualTo_WhenSubjectDoesNotEqualTheExpectedScheme_ShouldSucceed()
+			{
+				Uri subject = new("https://www.awexpect.com:80");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasScheme().NotEqualTo("https"));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task NotEqualTo_WhenSubjectEqualsExpectedScheme_ShouldFail()
+			{
+				Uri subject = new("https://www.awexpect.com:80");
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.HasScheme().NotEqualTo("http"));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has scheme equal to "http",
+					             but it had scheme "https"
+					             """);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds the `HasScheme` method for `Uri` objects to support verifying URI schemes in the testing framework.

### Key changes:
- Implements `HasScheme()` extension method that returns a `PropertyResult.String<Uri>` for scheme verification
- Adds comprehensive test coverage for both positive and negative assertion scenarios
- Updates the aweXpect.Core package dependency from version 2.22.2 to 2.23.0