### PR TITLE
docs: avoid link in headline

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,5 +1,7 @@
-# [aweXpect.Web](https://github.com/aweXpect/aweXpect.Web) [![Nuget](https://img.shields.io/nuget/v/aweXpect.Web)](https://www.nuget.org/packages/aweXpect.Web)
+# aweXpect.Web
 
-Expectations for `HttpClient`.
+[![Nuget](https://img.shields.io/nuget/v/aweXpect.Web)](https://www.nuget.org/packages/aweXpect.Web)
+
+[aweXpect.Web](https://github.com/aweXpect/aweXpect.Web) contains expectations for `HttpClient`.
 
 {README}


### PR DESCRIPTION
This PR removes a link from the main headline and relocates it to the description text to improve document formatting. Also the nuget package badge is moved to a separate line.