### PR TITLE
chore: bump the aweXpect group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="aweXpect" Version="2.25.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.23.0" />
-    <PackageVersion Include="aweXpect.Json" Version="1.4.0" />
+    <PackageVersion Include="aweXpect" Version="2.27.1" />
+    <PackageVersion Include="aweXpect.Core" Version="2.25.1" />
+    <PackageVersion Include="aweXpect.Json" Version="1.6.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>

--- a/Source/aweXpect.Web/Helpers/ThatExtensions.cs
+++ b/Source/aweXpect.Web/Helpers/ThatExtensions.cs
@@ -25,7 +25,7 @@ internal static class ThatExtensions
 		=> expectationBuilder.UpdateContexts(contexts => contexts
 			.Open()
 			.Clear()
-			.Add(new ResultContext(HttpRequestContext,
+			.Add(new ResultContext.AsyncCallback(HttpRequestContext,
 				async cancellationToken
 					=> await HttpFormatter.Format(request, "  ", cancellationToken)))
 			.Close());
@@ -38,7 +38,7 @@ internal static class ThatExtensions
 			return expectationBuilder.UpdateContexts(contexts => contexts
 				.Open()
 				.Clear()
-				.Add(new ResultContext(HttpResponseContext,
+				.Add(new ResultContext.AsyncCallback(HttpResponseContext,
 					async cancellationToken
 						=> await HttpFormatter.Format(response, "  ", cancellationToken)))
 				.Close());
@@ -47,10 +47,10 @@ internal static class ThatExtensions
 		return expectationBuilder.UpdateContexts(contexts => contexts
 			.Open()
 			.Clear()
-			.Add(new ResultContext(HttpRequestContext,
+			.Add(new ResultContext.AsyncCallback(HttpRequestContext,
 				async cancellationToken
 					=> await HttpFormatter.Format(response.RequestMessage, "  ", cancellationToken)))
-			.Add(new ResultContext(HttpResponseContext,
+			.Add(new ResultContext.AsyncCallback(HttpResponseContext,
 				async cancellationToken
 					=> await HttpFormatter.Format(response, "  ", cancellationToken)))
 			.Close());


### PR DESCRIPTION
This PR updates the aweXpect library group to newer versions and adapts the code to use the updated API.

- Updated aweXpect package versions to their latest releases
- Modified `ResultContext` constructor calls to use the new `AsyncCallback` API pattern