### PR TITLE
docs: notify Testably.Site when documentation changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,5 +251,5 @@ jobs:
                       -H "Accept: application/vnd.github+json" \
                       -H "Authorization: Bearer ${{ secrets.REPOSITORY_DISPATCH }}" \
                       -H "X-GitHub-Api-Version: 2022-11-28" \
-                      https://api.github.com/repos/aweXpect/aweXpect/dispatches \
+                      https://api.github.com/repos/Testably/aweXpect/dispatches \
                       -d "{\"event_type\": \"extension-documentation-updated-event\"}"

--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -1,0 +1,23 @@
+name: Notify Docs Site
+
+on:
+    push:
+        branches: [ main ]
+        paths:
+            - 'Docs/pages/**'
+            - 'README.md'
+    workflow_dispatch:
+
+jobs:
+    dispatch:
+        if: github.ref == 'refs/heads/main'
+        name: Trigger Site rebuild
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Dispatch extension-documentation-updated-event to Testably/Testably.Site
+                uses: peter-evans/repository-dispatch@v3
+                with:
+                    token: ${{ secrets.SITE_DISPATCH_TOKEN }}
+                    repository: Testably/Testably.Site
+                    event-type: extension-documentation-updated-event
+                    client-payload: '{"source": "${{ github.repository }}", "sha": "${{ github.sha }}"}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ All code should be covered by unit tests and comply with the coding guideline in
 
 As a framework for supporting unit testing, this project has a high standard for testing itself.  
 In order to support this, static code analysis is performed
-using [SonarCloud](https://sonarcloud.io/project/overview?id=aweXpect_aweXpect.Web) with quality gate requiring to
+using [SonarCloud](https://sonarcloud.io/project/overview?id=Testably_aweXpect.Web) with quality gate requiring to
 
 - solve all issues reported by SonarCloud
 - have a code coverage of > 90%

--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -2,6 +2,6 @@
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Web)](https://www.nuget.org/packages/aweXpect.Web)
 
-[aweXpect.Web](https://github.com/aweXpect/aweXpect.Web) contains expectations for `HttpClient`.
+[aweXpect.Web](https://github.com/Testably/aweXpect.Web) contains expectations for `HttpClient`.
 
 {README}

--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -16,8 +16,8 @@ partial class Build
 		.Executes(() =>
 		{
 			SonarScannerTasks.SonarScannerBegin(s => s
-				.SetOrganization("awexpect")
-				.SetProjectKey("aweXpect_aweXpect.Web")
+				.SetOrganization("testably")
+				.SetProjectKey("Testably_aweXpect.Web")
 				.AddVSTestReports(TestResultsDirectory / "*.trx")
 				.AddOpenCoverPaths(TestResultsDirectory / "reports" / "OpenCover.xml")
 				.SetPullRequestOrBranchName(GitHubActions, GitVersion)

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -70,7 +70,7 @@ partial class Build
 				                      {
 				                      	"stryker-config": {
 				                      		"project-info": {
-				                      			"name": "github.com/aweXpect/aweXpect.Web",
+				                      			"name": "github.com/Testably/aweXpect.Web",
 				                      			"module": "{{project.Key.Name}}",
 				                      			"version": "{{branchName}}"
 				                      		},
@@ -126,7 +126,7 @@ partial class Build
 
 			string body = "## :alien: Mutation Results"
 			              + Environment.NewLine
-			              + $"[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Web%2Fpull/{prId}/merge)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Web/pull/{prId}/merge)"
+			              + $"[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FaweXpect.Web%2Fpull/{prId}/merge)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/aweXpect.Web/pull/{prId}/merge)"
 			              + Environment.NewLine
 			              + MutationCommentBody;
 			File.WriteAllText(ArtifactsDirectory / "PR_Comment.md", body);
@@ -163,7 +163,7 @@ partial class Build
 				client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
 				// https://stryker-mutator.io/docs/General/dashboard/#send-a-report-via-curl
 				await client.PutAsync(
-					$"https://dashboard.stryker-mutator.io/api/reports/github.com/aweXpect/aweXpect.Web/{branchName}?module={project.Key.Name}",
+					$"https://dashboard.stryker-mutator.io/api/reports/github.com/Testably/aweXpect.Web/{branchName}?module={project.Key.Name}",
 					new StringContent(reportComment, new MediaTypeHeaderValue("application/json")));
 			}
 

--- a/Pipeline/Build.Pack.cs
+++ b/Pipeline/Build.Pack.cs
@@ -29,10 +29,10 @@ partial class Build
 			string[] lines = File.ReadAllLines(Solution.Directory / "README.md");
 			sb.AppendLine(lines.First());
 			sb.AppendLine(
-				$"[![Changelog](https://img.shields.io/badge/Changelog-v{version}-blue)](https://github.com/aweXpect/aweXpect.Web/releases/tag/v{version})");
+				$"[![Changelog](https://img.shields.io/badge/Changelog-v{version}-blue)](https://github.com/Testably/aweXpect.Web/releases/tag/v{version})");
 			foreach (string line in lines.Skip(1))
 			{
-				if (line.StartsWith("[![Build](https://github.com/aweXpect/aweXpect.Web/actions/workflows/build.yml") ||
+				if (line.StartsWith("[![Build](https://github.com/Testably/aweXpect.Web/actions/workflows/build.yml") ||
 				    line.StartsWith("[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure"))
 				{
 					continue;

--- a/Pipeline/BuildExtensions.cs
+++ b/Pipeline/BuildExtensions.cs
@@ -53,7 +53,7 @@ public static class BuildExtensions
 		client.DefaultRequestHeaders.UserAgent.ParseAdd("aweXpect");
 		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubToken);
 		HttpResponseMessage response = await client.GetAsync(
-			$"https://api.github.com/repos/aweXpect/aweXpect.Web/actions/runs/{runId}/artifacts");
+			$"https://api.github.com/repos/Testably/aweXpect.Web/actions/runs/{runId}/artifacts");
 
 		string responseContent = await response.Content.ReadAsStringAsync();
 		if (!response.IsSuccessStatusCode)
@@ -72,7 +72,7 @@ public static class BuildExtensions
 				{
 					long artifactId = artifact.GetProperty("id").GetInt64();
 					HttpResponseMessage fileResponse = await client.GetAsync(
-						$"https://api.github.com/repos/aweXpect/aweXpect.Web/actions/artifacts/{artifactId}/zip");
+						$"https://api.github.com/repos/Testably/aweXpect.Web/actions/artifacts/{artifactId}/zip");
 					if (fileResponse.IsSuccessStatusCode)
 					{
 						using ZipArchive archive = new(await fileResponse.Content.ReadAsStreamAsync());

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # aweXpect.Web
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Web)](https://www.nuget.org/packages/aweXpect.Web)
-[![Build](https://github.com/aweXpect/aweXpect.Web/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/aweXpect.Web/actions/workflows/build.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Web&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect.Web)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Web&metric=coverage)](https://sonarcloud.io/summary/overall?id=aweXpect_aweXpect.Web)
-[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Web%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Web/main)
+[![Build](https://github.com/Testably/aweXpect.Web/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/aweXpect.Web/actions/workflows/build.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Web&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_aweXpect.Web)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Web&metric=coverage)](https://sonarcloud.io/summary/overall?id=Testably_aweXpect.Web)
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FaweXpect.Web%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/aweXpect.Web/main)
 
-Web extensions for [aweXpect](https://github.com/aweXpect/aweXpect).
+Web extensions for [aweXpect](https://github.com/Testably/aweXpect).
 
 ## `HttpRequestMessage`
 
@@ -15,7 +15,7 @@ Web extensions for [aweXpect](https://github.com/aweXpect/aweXpect).
 You can verify, the method of the `HttpRequestMessage`:
 
 ```csharp
-var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/Testably/aweXpect.Web");
 
 await Expect.That(request).HasMethod(HttpMethod.Get);
 ```
@@ -25,10 +25,10 @@ await Expect.That(request).HasMethod(HttpMethod.Get);
 You can verify, the request URI of the `HttpRequestMessage`:
 
 ```csharp
-var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/Testably/aweXpect.Web");
 
-await Expect.That(request).HasRequestUri("https://github.com/aweXpect/aweXpect.Web");
-await Expect.That(request).HasRequestUri(new Uri("https://github.com/aweXpect/aweXpect.Web"));
+await Expect.That(request).HasRequestUri("https://github.com/Testably/aweXpect.Web");
+await Expect.That(request).HasRequestUri(new Uri("https://github.com/Testably/aweXpect.Web"));
 ```
 
 ### Header
@@ -36,7 +36,7 @@ await Expect.That(request).HasRequestUri(new Uri("https://github.com/aweXpect/aw
 You can verify the headers of the `HttpRequestMessage`:
 
 ```csharp
-HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/Testably/aweXpect.Web");
 // Add headers
 
 await Expect.That(request).HasHeader("X-GitHub-Request-Id");
@@ -49,7 +49,7 @@ await Expect.That(request).DoesNotHaveHeader("X-My-Header");
 You can also add additional expectations on the header value(s):
 
 ```csharp
-HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/aweXpect/aweXpect.Web");
+HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/Testably/aweXpect.Web");
 // Add headers
 
 await Expect.That(request).HasHeader("X-GitHub-Request-Id")
@@ -63,7 +63,7 @@ await Expect.That(request).HasHeader("Vary")
 You can verify, the content of the `HttpRequestMessage`:
 
 ```csharp
-var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/aweXpect/aweXpect.Web")
+var request = new HttpRequestMessage(HttpMethod.Post, "https://github.com/Testably/aweXpect.Web")
 {
 	Content = new StringContent("my aweXpect content")
 };
@@ -81,11 +81,11 @@ when [comparing strings](https://awexpect.com/docs/expectations/string#equality)
 You can verify the status code of the `HttpResponseMessage`:
 
 ```csharp
-HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");
+HttpResponseMessage response = await httpClient.GetAsync("https://github.com/Testably/aweXpect.Web");
 await Expect.That(response).HasStatusCode().Success();
 await Expect.That(response).HasStatusCode(HttpStatusCode.OK);
 
-response = await httpClient.PostAsync("https://github.com/aweXpect/aweXpect.Web", new StringContent(""));
+response = await httpClient.PostAsync("https://github.com/Testably/aweXpect.Web", new StringContent(""));
 await Expect.That(response).HasStatusCode().ClientError().Or.HasStatusCode().ServerError().Or.HasStatusCode().Redirection();
 ```
 
@@ -94,7 +94,7 @@ await Expect.That(response).HasStatusCode().ClientError().Or.HasStatusCode().Ser
 You can verify the headers of the `HttpResponseMessage`:
 
 ```csharp
-HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");
+HttpResponseMessage response = await httpClient.GetAsync("https://github.com/Testably/aweXpect.Web");
 
 await Expect.That(response).HasHeader("X-GitHub-Request-Id");
 await Expect.That(response).HasHeader("Cache-Control")
@@ -106,7 +106,7 @@ await Expect.That(response).DoesNotHaveHeader("X-My-Header");
 You can also add additional expectations on the header value(s):
 
 ```csharp
-HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect.Web");
+HttpResponseMessage response = await httpClient.GetAsync("https://github.com/Testably/aweXpect.Web");
 
 await Expect.That(response).HasHeader("X-GitHub-Request-Id")
     .WhoseValue(value => value.IsNotEmpty());
@@ -119,7 +119,7 @@ await Expect.That(response).HasHeader("Vary")
 You can verify, the content of the `HttpResponseMessage`:
 
 ```csharp
-HttpResponseMessage response = await httpClient.GetAsync("https://github.com/aweXpect/aweXpect");
+HttpResponseMessage response = await httpClient.GetAsync("https://github.com/Testably/aweXpect");
 
 await Expect.That(response).HasContent("*aweXpect*").AsWildcard();
 ```
@@ -135,7 +135,7 @@ The response could look similar to:
 > but it was 404 NotFound
 > 
 > HTTP-Request:
->   GET https://github.com/aweXpect/missing-repo HTTP/1.1
+>   GET https://github.com/Testably/missing-repo HTTP/1.1
 > 
 > HTTP-Response:
 >   404 NotFound HTTP/1.1

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -7,7 +7,7 @@
 		<Authors>aweXpect</Authors>
 		<Description>Web extensions for aweXpect.</Description>
 		<Copyright>Copyright (c) 2025 - $([System.DateTime]::Now.ToString('yyyy')) Valentin Breuß</Copyright>
-		<RepositoryUrl>https://github.com/aweXpect/aweXpect.Web.git</RepositoryUrl>
+		<RepositoryUrl>https://github.com/Testably/aweXpect.Web.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/logo_256x256.png</PackageIcon>

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_net8.0.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/aweXpect.Web.git")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/aweXpect.Web.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"aweXpect.Web.Internal.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100bd818c7b1f408c9cae5e376d754fadbead7aa6046aaf3f4911a9c032c2ca4ccd46d6d2d5c9158a15a8639f34d6bfafc236c19e9158dd8fce375c43069256487d9be2dc05ab53fb90e3e9d8241c0ff0f70133bd74e88683ff1317b1b09ae6fd6ddc6fba1454e9d5487a97af791dd5fc73383f194b3be6e441e878a8691a1518e1")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace aweXpect

--- a/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
+++ b/Tests/aweXpect.Web.Api.Tests/Expected/aweXpect.Web_netstandard2.0.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/aweXpect.Web.git")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/aweXpect.Web.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"aweXpect.Web.Internal.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100bd818c7b1f408c9cae5e376d754fadbead7aa6046aaf3f4911a9c032c2ca4ccd46d6d2d5c9158a15a8639f34d6bfafc236c19e9158dd8fce375c43069256487d9be2dc05ab53fb90e3e9d8241c0ff0f70133bd74e88683ff1317b1b09ae6fd6ddc6fba1454e9d5487a97af791dd5fc73383f194b3be6e441e878a8691a1518e1")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace aweXpect


### PR DESCRIPTION
Adds a workflow that fires the extension-documentation-updated-event repository dispatch at Testably/Testably.Site whenever Docs/pages/** or README.md changes on main. README.md is included because aweXpect's docs aggregator inlines it into 00-index.md via a {README} placeholder, so README changes affect the rendered site.

Requires a SITE_DISPATCH_TOKEN secret with repo write on Testably/ Testably.Site (recommended: configure once at the Testably org level).