### PR TITLE
fix: trigger Testably.Site rebuild after main build

### DIFF
--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -1,16 +1,15 @@
 name: Notify Docs Site
 
 on:
-    push:
+    workflow_run:
+        workflows: [ "Build" ]
+        types: [ completed ]
         branches: [ main ]
-        paths:
-            - 'Docs/pages/**'
-            - 'README.md'
     workflow_dispatch:
 
 jobs:
     dispatch:
-        if: github.ref == 'refs/heads/main'
+        if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
         name: Trigger Site rebuild
         runs-on: ubuntu-latest
         steps:
@@ -20,4 +19,4 @@ jobs:
                     token: ${{ secrets.SITE_DISPATCH_TOKEN }}
                     repository: Testably/Testably.Site
                     event-type: extension-documentation-updated-event
-                    client-payload: '{"source": "${{ github.repository }}", "sha": "${{ github.sha }}"}'
+                    client-payload: '{"source": "${{ github.repository }}", "sha": "${{ github.event.workflow_run.head_sha || github.sha }}"}'


### PR DESCRIPTION
Switch the Notify Docs Site trigger from a push path filter to workflow_run of the Build workflow, matching the pattern used by all other aweXpect extensions.